### PR TITLE
Add DigiByte network support

### DIFF
--- a/cw_bitcoin/lib/bitcoin_wallet.dart
+++ b/cw_bitcoin/lib/bitcoin_wallet.dart
@@ -38,6 +38,18 @@ part 'bitcoin_wallet.g.dart';
 class BitcoinWallet = BitcoinWalletBase with _$BitcoinWallet;
 
 abstract class BitcoinWalletBase extends ElectrumWallet with Store {
+  static CryptoCurrency _currencyForNetwork(BasedUtxoNetwork network) {
+    if (network == BitcoinNetwork.testnet) {
+      return CryptoCurrency.tbtc;
+    }
+    if (network is LitecoinNetwork) {
+      return CryptoCurrency.ltc;
+    }
+    if (network is DigibyteNetwork) {
+      return CryptoCurrency.digibyte;
+    }
+    return CryptoCurrency.btc;
+  }
   BitcoinWalletBase({
     required String password,
     required WalletInfo walletInfo,
@@ -64,18 +76,12 @@ abstract class BitcoinWalletBase extends ElectrumWallet with Store {
           password: password,
           walletInfo: walletInfo,
           unspentCoinsInfo: unspentCoinsInfo,
-          network: networkParam == null
-              ? BitcoinNetwork.mainnet
-              : networkParam == BitcoinNetwork.mainnet
-                  ? BitcoinNetwork.mainnet
-                  : BitcoinNetwork.testnet,
+          network: networkParam ?? BitcoinNetwork.mainnet,
           initialAddresses: initialAddresses,
           initialBalance: initialBalance,
           seedBytes: seedBytes,
           encryptionFileUtils: encryptionFileUtils,
-          currency: networkParam == BitcoinNetwork.testnet
-              ? CryptoCurrency.tbtc
-              : CryptoCurrency.btc,
+          currency: _currencyForNetwork(networkParam ?? BitcoinNetwork.mainnet),
           alwaysScan: alwaysScan,
         ) {
     // in a standard BIP44 wallet, mainHd derivation path = m/84'/0'/0'/0 (account 0, index unspecified here)

--- a/cw_bitcoin/lib/electrum_wallet.dart
+++ b/cw_bitcoin/lib/electrum_wallet.dart
@@ -121,6 +121,7 @@ abstract class ElectrumWalletBase
         case CryptoCurrency.btc:
         case CryptoCurrency.ltc:
         case CryptoCurrency.tbtc:
+        case CryptoCurrency.digibyte:
           return Bip32Slip10Secp256k1.fromSeed(seedBytes, getKeyNetVersion(network)).derivePath(
                   _hardenedDerivationPath(derivationInfo?.derivationPath ?? electrum_path))
               as Bip32Slip10Secp256k1;

--- a/cw_core/lib/currency_for_wallet_type.dart
+++ b/cw_core/lib/currency_for_wallet_type.dart
@@ -34,6 +34,8 @@ CryptoCurrency currencyForWalletType(WalletType type, {bool? isTestnet}) {
       return CryptoCurrency.zano;
     case WalletType.decred:
       return CryptoCurrency.dcr;
+    case WalletType.digibyte:
+      return CryptoCurrency.digibyte;
     case WalletType.none:
       throw Exception(
           'Unexpected wallet type: ${type.toString()} for CryptoCurrency currencyForWalletType');
@@ -70,6 +72,8 @@ WalletType? walletTypeForCurrency(CryptoCurrency currency) {
       return WalletType.zano;
     case CryptoCurrency.dcr:
       return WalletType.decred;
+    case CryptoCurrency.digibyte:
+      return WalletType.digibyte;
     default:
       return null;
   }

--- a/cw_core/lib/wallet_type.dart
+++ b/cw_core/lib/wallet_type.dart
@@ -18,6 +18,7 @@ const walletTypes = [
   WalletType.tron,
   WalletType.zano,
   WalletType.decred,
+  WalletType.digibyte,
 ];
 
 @HiveType(typeId: WALLET_TYPE_TYPE_ID)
@@ -66,6 +67,10 @@ enum WalletType {
 
   @HiveField(14)
   decred
+  ,
+
+  @HiveField(15)
+  digibyte
 }
 
 int serializeToInt(WalletType type) {
@@ -98,6 +103,8 @@ int serializeToInt(WalletType type) {
       return 12;
     case WalletType.decred:
       return 13;
+    case WalletType.digibyte:
+      return 14;
     case WalletType.none:
       return -1;
   }
@@ -133,6 +140,8 @@ WalletType deserializeFromInt(int raw) {
       return WalletType.zano;
     case 13:
       return WalletType.decred;
+    case 14:
+      return WalletType.digibyte;
     default:
       throw Exception(
           'Unexpected token: $raw for WalletType deserializeFromInt');
@@ -169,6 +178,8 @@ String walletTypeToString(WalletType type) {
       return 'Zano';
     case WalletType.decred:
       return 'Decred';
+    case WalletType.digibyte:
+      return 'DigiByte';
     case WalletType.none:
       return '';
   }
@@ -204,6 +215,8 @@ String walletTypeToDisplayName(WalletType type) {
       return 'Zano (ZANO)';
     case WalletType.decred:
       return 'Decred (DCR)';
+    case WalletType.digibyte:
+      return 'DigiByte (DGB)';
     case WalletType.none:
       return '';
   }
@@ -242,6 +255,8 @@ CryptoCurrency walletTypeToCryptoCurrency(WalletType type, {bool isTestnet = fal
       return CryptoCurrency.zano;
     case WalletType.decred:
       return CryptoCurrency.dcr;
+    case WalletType.digibyte:
+      return CryptoCurrency.digibyte;
     case WalletType.none:
       throw Exception(
           'Unexpected wallet type: ${type.toString()} for CryptoCurrency walletTypeToCryptoCurrency');
@@ -278,6 +293,8 @@ WalletType? cryptoCurrencyToWalletType(CryptoCurrency type) {
       return WalletType.zano;
     case CryptoCurrency.dcr:
       return WalletType.decred;
+    case CryptoCurrency.digibyte:
+      return WalletType.digibyte;
     default:
       return null;
   }

--- a/lib/bitcoin/cw_bitcoin.dart
+++ b/lib/bitcoin/cw_bitcoin.dart
@@ -242,6 +242,16 @@ class CWBitcoin extends Bitcoin {
     return LitecoinWalletService(walletInfoSource, unspentCoinSource, alwaysScan, isDirect);
   }
 
+  WalletService createDigibyteWalletService(
+      Box<WalletInfo> walletInfoSource,
+      Box<UnspentCoinsInfo> unspentCoinSource,
+      Box<PayjoinSession> payjoinSessionSource,
+      bool alwaysScan,
+      bool isDirect) {
+    return BitcoinWalletService(
+        walletInfoSource, unspentCoinSource, payjoinSessionSource, alwaysScan, isDirect);
+  }
+
   @override
   TransactionPriority getBitcoinTransactionPriorityMedium() => BitcoinTransactionPriority.medium;
 

--- a/lib/di.dart
+++ b/lib/di.dart
@@ -1116,6 +1116,14 @@ Future<void> setup({
           getIt.get<SettingsStore>().mwebAlwaysScan,
           SettingsStoreBase.walletPasswordDirectInput,
         );
+      case WalletType.digibyte:
+        return bitcoin!.createDigibyteWalletService(
+          _walletInfoSource,
+          _unspentCoinsInfoSource,
+          _payjoinSessionSource,
+          getIt.get<SettingsStore>().silentPaymentsAlwaysScan,
+          SettingsStoreBase.walletPasswordDirectInput,
+        );
       case WalletType.ethereum:
         return ethereum!.createEthereumWalletService(
             _walletInfoSource, SettingsStoreBase.walletPasswordDirectInput);


### PR DESCRIPTION
## Summary
- expand Bitcoin wallet logic to derive currency from the network and handle DigiByte
- support DigiByte in HD wallet generation
- register the new WalletType.digibyte and currency mappings
- wire up DI to produce DigiByte wallet services

## Testing
- `dart format` *(fails: `dart: command not found`)*