### PR TITLE
Fix README on DGB purchase

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Cake Wallet includes support for several cryptocurrencies, including:
 * Tron (TRX)
 * Nano (XNO)
 * Zano (ZANO)
+* DigiByte (DGB)
 * Decred (DCR)
 * Wownero (WOW)
 
@@ -41,7 +42,7 @@ Cake Wallet includes support for several cryptocurrencies, including:
 * Completely noncustodial. *Your keys, your coins.*
 * Built-in exchange for dozens of pairs
 * Easily pay cryptocurrency invoices with fixed rate exchanges
-* Buy cryptocurrency (BTC/LTC/XMR/ETH) with credit/debit/bank
+* Buy cryptocurrency (BTC/LTC/XMR/ETH) with credit/debit/bank (DGB not available for direct purchase)
 * Sell cryptocurrency by bank transfer
 * Scan QR codes for easy cryptocurrency transfers
 * Create several wallets


### PR DESCRIPTION
## Summary
- clarify that DGB can't be purchased directly
- list DGB among supported currencies

## Testing
- `git log -1 --stat`