### PR TITLE
Add DigiByte default node to migrations

### DIFF
--- a/lib/entities/default_settings_migration.dart
+++ b/lib/entities/default_settings_migration.dart
@@ -33,6 +33,7 @@ const publicBitcoinTestnetElectrumPort = '50002';
 const publicBitcoinTestnetElectrumUri =
     '$publicBitcoinTestnetElectrumAddress:$publicBitcoinTestnetElectrumPort';
 const cakeWalletLitecoinElectrumUri = 'ltc-electrum.cakewallet.com:50002';
+const cakeWalletDigibyteElectrumUri = 'electrumx.digibyte.io:50002';
 const havenDefaultNodeUri = 'nodes.havenprotocol.org:443';
 const ethereumDefaultNodeUri = 'ethereum-rpc.publicnode.com';
 const polygonDefaultNodeUri = 'polygon-bor-rpc.publicnode.com';
@@ -597,6 +598,8 @@ String _getDefaultNodeUri(WalletType type) {
       return newCakeWalletBitcoinUri;
     case WalletType.litecoin:
       return cakeWalletLitecoinElectrumUri;
+    case WalletType.digibyte:
+      return cakeWalletDigibyteElectrumUri;
     case WalletType.haven:
       return havenDefaultNodeUri;
     case WalletType.ethereum:
@@ -643,6 +646,7 @@ Future<void> _fixNodesUseSSLFlag(Box<Node> nodes) async {
       case cakeWalletLitecoinElectrumUri:
       case cakeWalletBitcoinElectrumUri:
       case newCakeWalletBitcoinUri:
+      case cakeWalletDigibyteElectrumUri:
       case newCakeWalletMoneroUri:
         node.useSSL = true;
         node.trusted = true;
@@ -1039,6 +1043,8 @@ Future<void> checkCurrentNodes(
       sharedPreferences.getInt(PreferencesKey.currentBitcoinElectrumSererIdKey);
   final currentLitecoinElectrumSeverId =
       sharedPreferences.getInt(PreferencesKey.currentLitecoinElectrumSererIdKey);
+  final currentDigibyteElectrumSeverId =
+      sharedPreferences.getInt(PreferencesKey.currentDigibyteElectrumSererIdKey);
   final currentHavenNodeId = sharedPreferences.getInt(PreferencesKey.currentHavenNodeIdKey);
   final currentEthereumNodeId = sharedPreferences.getInt(PreferencesKey.currentEthereumNodeIdKey);
   final currentPolygonNodeId = sharedPreferences.getInt(PreferencesKey.currentPolygonNodeIdKey);
@@ -1057,6 +1063,8 @@ Future<void> checkCurrentNodes(
       nodeSource.values.firstWhereOrNull((node) => node.key == currentBitcoinElectrumSeverId);
   final currentLitecoinElectrumServer =
       nodeSource.values.firstWhereOrNull((node) => node.key == currentLitecoinElectrumSeverId);
+  final currentDigibyteElectrumServer =
+      nodeSource.values.firstWhereOrNull((node) => node.key == currentDigibyteElectrumSeverId);
   final currentHavenNodeServer =
       nodeSource.values.firstWhereOrNull((node) => node.key == currentHavenNodeId);
   final currentEthereumNodeServer =
@@ -1103,6 +1111,14 @@ Future<void> checkCurrentNodes(
     await nodeSource.add(cakeWalletElectrum);
     await sharedPreferences.setInt(
         PreferencesKey.currentLitecoinElectrumSererIdKey, cakeWalletElectrum.key as int);
+  }
+
+  if (currentDigibyteElectrumServer == null) {
+    final cakeWalletElectrum =
+        Node(uri: cakeWalletDigibyteElectrumUri, type: WalletType.digibyte, useSSL: false);
+    await nodeSource.add(cakeWalletElectrum);
+    await sharedPreferences.setInt(
+        PreferencesKey.currentDigibyteElectrumSererIdKey, cakeWalletElectrum.key as int);
   }
 
   if (currentHavenNodeServer == null) {

--- a/lib/entities/node_list.dart
+++ b/lib/entities/node_list.dart
@@ -16,6 +16,9 @@ Future<List<Node>> loadDefaultNodes(WalletType type) async {
     case WalletType.litecoin:
       path = 'assets/litecoin_electrum_server_list.yml';
       break;
+    case WalletType.digibyte:
+      path = 'assets/digibyte_electrum_server_list.yml';
+      break;
     case WalletType.haven:
       path = 'assets/haven_node_list.yml';
       break;
@@ -87,6 +90,7 @@ Future<void> resetToDefault(Box<Node> nodeSource) async {
   final moneroNodes = await loadDefaultNodes(WalletType.monero);
   final bitcoinElectrumServerList = await loadDefaultNodes(WalletType.bitcoin);
   final litecoinElectrumServerList = await loadDefaultNodes(WalletType.litecoin);
+  final digibyteElectrumServerList = await loadDefaultNodes(WalletType.digibyte);
   final bitcoinCashElectrumServerList = await loadDefaultNodes(WalletType.bitcoinCash);
   final havenNodes = await loadDefaultNodes(WalletType.haven);
   final ethereumNodes = await loadDefaultNodes(WalletType.ethereum);
@@ -100,6 +104,7 @@ Future<void> resetToDefault(Box<Node> nodeSource) async {
   final nodes = moneroNodes +
       bitcoinElectrumServerList +
       litecoinElectrumServerList +
+      digibyteElectrumServerList +
       havenNodes +
       ethereumNodes +
       bitcoinCashElectrumServerList +

--- a/lib/entities/preferences_key.dart
+++ b/lib/entities/preferences_key.dart
@@ -4,6 +4,7 @@ class PreferencesKey {
   static const currentNodeIdKey = 'current_node_id';
   static const currentBitcoinElectrumSererIdKey = 'current_node_id_btc';
   static const currentLitecoinElectrumSererIdKey = 'current_node_id_ltc';
+  static const currentDigibyteElectrumSererIdKey = 'current_node_id_dgb';
   static const currentHavenNodeIdKey = 'current_node_id_xhv';
   static const currentZanoNodeIdKey = 'current_node_id_zano';
   static const currentEthereumNodeIdKey = 'current_node_id_eth';


### PR DESCRIPTION
## Summary
- define `cakeWalletDigibyteElectrumUri`
- support DigiByte nodes in the node list helpers
- insert a DigiByte electrum node in migrations when none configured
- track the DigiByte node preference key

## Testing
- `flutter --version` *(fails: command not found)*