### PR TITLE
Add DigiByte wallet mapping

### DIFF
--- a/cw_core/lib/currency_for_wallet_type.dart
+++ b/cw_core/lib/currency_for_wallet_type.dart
@@ -34,6 +34,8 @@ CryptoCurrency currencyForWalletType(WalletType type, {bool? isTestnet}) {
       return CryptoCurrency.zano;
     case WalletType.decred:
       return CryptoCurrency.dcr;
+    case WalletType.digibyte:
+      return CryptoCurrency.digibyte;
     case WalletType.none:
       throw Exception(
           'Unexpected wallet type: ${type.toString()} for CryptoCurrency currencyForWalletType');
@@ -70,6 +72,8 @@ WalletType? walletTypeForCurrency(CryptoCurrency currency) {
       return WalletType.zano;
     case CryptoCurrency.dcr:
       return WalletType.decred;
+    case CryptoCurrency.digibyte:
+      return WalletType.digibyte;
     default:
       return null;
   }


### PR DESCRIPTION
## Summary
- add DigiByte case in `currencyForWalletType`
- map `CryptoCurrency.digibyte` back to `WalletType.digibyte`

## Testing
- `This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.`