### PR TITLE
Add DigiByte node & priority settings

### DIFF
--- a/cw_core/lib/wallet_type.dart
+++ b/cw_core/lib/wallet_type.dart
@@ -18,6 +18,7 @@ const walletTypes = [
   WalletType.tron,
   WalletType.zano,
   WalletType.decred,
+  WalletType.digibyte,
 ];
 
 @HiveType(typeId: WALLET_TYPE_TYPE_ID)
@@ -65,7 +66,10 @@ enum WalletType {
   zano,
 
   @HiveField(14)
-  decred
+  decred,
+
+  @HiveField(15)
+  digibyte
 }
 
 int serializeToInt(WalletType type) {
@@ -98,6 +102,8 @@ int serializeToInt(WalletType type) {
       return 12;
     case WalletType.decred:
       return 13;
+    case WalletType.digibyte:
+      return 14;
     case WalletType.none:
       return -1;
   }
@@ -133,6 +139,8 @@ WalletType deserializeFromInt(int raw) {
       return WalletType.zano;
     case 13:
       return WalletType.decred;
+    case 14:
+      return WalletType.digibyte;
     default:
       throw Exception(
           'Unexpected token: $raw for WalletType deserializeFromInt');
@@ -169,6 +177,8 @@ String walletTypeToString(WalletType type) {
       return 'Zano';
     case WalletType.decred:
       return 'Decred';
+    case WalletType.digibyte:
+      return 'DigiByte';
     case WalletType.none:
       return '';
   }
@@ -204,6 +214,8 @@ String walletTypeToDisplayName(WalletType type) {
       return 'Zano (ZANO)';
     case WalletType.decred:
       return 'Decred (DCR)';
+    case WalletType.digibyte:
+      return 'DigiByte (DGB)';
     case WalletType.none:
       return '';
   }
@@ -242,6 +254,8 @@ CryptoCurrency walletTypeToCryptoCurrency(WalletType type, {bool isTestnet = fal
       return CryptoCurrency.zano;
     case WalletType.decred:
       return CryptoCurrency.dcr;
+    case WalletType.digibyte:
+      return CryptoCurrency.digibyte;
     case WalletType.none:
       throw Exception(
           'Unexpected wallet type: ${type.toString()} for CryptoCurrency walletTypeToCryptoCurrency');
@@ -278,6 +292,8 @@ WalletType? cryptoCurrencyToWalletType(CryptoCurrency type) {
       return WalletType.zano;
     case CryptoCurrency.dcr:
       return WalletType.decred;
+    case CryptoCurrency.digibyte:
+      return WalletType.digibyte;
     default:
       return null;
   }

--- a/lib/entities/default_settings_migration.dart
+++ b/lib/entities/default_settings_migration.dart
@@ -33,6 +33,7 @@ const publicBitcoinTestnetElectrumPort = '50002';
 const publicBitcoinTestnetElectrumUri =
     '$publicBitcoinTestnetElectrumAddress:$publicBitcoinTestnetElectrumPort';
 const cakeWalletLitecoinElectrumUri = 'ltc-electrum.cakewallet.com:50002';
+const cakeWalletDigibyteElectrumUri = 'electrumx.digibyte.io:50002';
 const havenDefaultNodeUri = 'nodes.havenprotocol.org:443';
 const ethereumDefaultNodeUri = 'ethereum-rpc.publicnode.com';
 const polygonDefaultNodeUri = 'polygon-bor-rpc.publicnode.com';
@@ -597,6 +598,8 @@ String _getDefaultNodeUri(WalletType type) {
       return newCakeWalletBitcoinUri;
     case WalletType.litecoin:
       return cakeWalletLitecoinElectrumUri;
+    case WalletType.digibyte:
+      return cakeWalletDigibyteElectrumUri;
     case WalletType.haven:
       return havenDefaultNodeUri;
     case WalletType.ethereum:
@@ -641,6 +644,7 @@ Future<void> _fixNodesUseSSLFlag(Box<Node> nodes) async {
   for (Node node in nodes.values) {
     switch (node.uriRaw) {
       case cakeWalletLitecoinElectrumUri:
+      case cakeWalletDigibyteElectrumUri:
       case cakeWalletBitcoinElectrumUri:
       case newCakeWalletBitcoinUri:
       case newCakeWalletMoneroUri:

--- a/lib/entities/preferences_key.dart
+++ b/lib/entities/preferences_key.dart
@@ -4,6 +4,7 @@ class PreferencesKey {
   static const currentNodeIdKey = 'current_node_id';
   static const currentBitcoinElectrumSererIdKey = 'current_node_id_btc';
   static const currentLitecoinElectrumSererIdKey = 'current_node_id_ltc';
+  static const currentDigibyteElectrumSererIdKey = 'current_node_id_dgb';
   static const currentHavenNodeIdKey = 'current_node_id_xhv';
   static const currentZanoNodeIdKey = 'current_node_id_zano';
   static const currentEthereumNodeIdKey = 'current_node_id_eth';
@@ -44,6 +45,7 @@ class PreferencesKey {
   static const bitcoinTransactionPriority = 'current_fee_priority_bitcoin';
   static const havenTransactionPriority = 'current_fee_priority_haven';
   static const litecoinTransactionPriority = 'current_fee_priority_litecoin';
+  static const digibyteTransactionPriority = 'current_fee_priority_digibyte';
   static const ethereumTransactionPriority = 'current_fee_priority_ethereum';
   static const polygonTransactionPriority = 'current_fee_priority_polygon';
   static const bitcoinCashTransactionPriority = 'current_fee_priority_bitcoin_cash';

--- a/lib/store/settings_store.dart
+++ b/lib/store/settings_store.dart
@@ -135,6 +135,7 @@ abstract class SettingsStoreBase with Store {
       TransactionPriority? initialWowneroTransactionPriority,
       TransactionPriority? initialHavenTransactionPriority,
       TransactionPriority? initialLitecoinTransactionPriority,
+      TransactionPriority? initialDigibyteTransactionPriority,
       TransactionPriority? initialEthereumTransactionPriority,
       TransactionPriority? initialPolygonTransactionPriority,
       TransactionPriority? initialBitcoinCashTransactionPriority,
@@ -210,6 +211,10 @@ abstract class SettingsStoreBase with Store {
       priority[WalletType.litecoin] = initialLitecoinTransactionPriority;
     }
 
+    if (initialDigibyteTransactionPriority != null) {
+      priority[WalletType.digibyte] = initialDigibyteTransactionPriority;
+    }
+
     if (initialEthereumTransactionPriority != null) {
       priority[WalletType.ethereum] = initialEthereumTransactionPriority;
     }
@@ -267,6 +272,9 @@ abstract class SettingsStoreBase with Store {
           break;
         case WalletType.litecoin:
           key = PreferencesKey.litecoinTransactionPriority;
+          break;
+        case WalletType.digibyte:
+          key = PreferencesKey.digibyteTransactionPriority;
           break;
         case WalletType.haven:
           key = PreferencesKey.havenTransactionPriority;
@@ -903,6 +911,7 @@ abstract class SettingsStoreBase with Store {
 
     TransactionPriority? havenTransactionPriority;
     TransactionPriority? litecoinTransactionPriority;
+    TransactionPriority? digibyteTransactionPriority;
     TransactionPriority? ethereumTransactionPriority;
     TransactionPriority? polygonTransactionPriority;
     TransactionPriority? bitcoinCashTransactionPriority;
@@ -917,6 +926,10 @@ abstract class SettingsStoreBase with Store {
     if (sharedPreferences.getInt(PreferencesKey.litecoinTransactionPriority) != null) {
       litecoinTransactionPriority = bitcoin?.deserializeLitecoinTransactionPriority(
           sharedPreferences.getInt(PreferencesKey.litecoinTransactionPriority)!);
+    }
+    if (sharedPreferences.getInt(PreferencesKey.digibyteTransactionPriority) != null) {
+      digibyteTransactionPriority = bitcoin?.deserializeLitecoinTransactionPriority(
+          sharedPreferences.getInt(PreferencesKey.digibyteTransactionPriority)!);
     }
     if (sharedPreferences.getInt(PreferencesKey.ethereumTransactionPriority) != null) {
       ethereumTransactionPriority = ethereum?.deserializeEthereumTransactionPriority(
@@ -947,6 +960,7 @@ abstract class SettingsStoreBase with Store {
     bitcoinTransactionPriority ??= bitcoin?.getMediumTransactionPriority();
     havenTransactionPriority ??= monero?.getDefaultTransactionPriority();
     litecoinTransactionPriority ??= bitcoin?.getLitecoinTransactionPriorityMedium();
+    digibyteTransactionPriority ??= bitcoin?.getLitecoinTransactionPriorityMedium();
     ethereumTransactionPriority ??= ethereum?.getDefaultTransactionPriority();
     bitcoinCashTransactionPriority ??= bitcoinCash?.getDefaultTransactionPriority();
     wowneroTransactionPriority ??= wownero?.getDefaultTransactionPriority();
@@ -1044,6 +1058,8 @@ abstract class SettingsStoreBase with Store {
         sharedPreferences.getInt(PreferencesKey.currentBitcoinElectrumSererIdKey);
     final litecoinElectrumServerId =
         sharedPreferences.getInt(PreferencesKey.currentLitecoinElectrumSererIdKey);
+    final digibyteElectrumServerId =
+        sharedPreferences.getInt(PreferencesKey.currentDigibyteElectrumSererIdKey);
     final bitcoinCashElectrumServerId =
         sharedPreferences.getInt(PreferencesKey.currentBitcoinCashNodeIdKey);
     final ethereumNodeId = sharedPreferences.getInt(PreferencesKey.currentEthereumNodeIdKey);
@@ -1063,6 +1079,8 @@ abstract class SettingsStoreBase with Store {
         nodeSource.values.firstWhereOrNull((e) => e.uriRaw == newCakeWalletBitcoinUri);
     final litecoinElectrumServer = nodeSource.get(litecoinElectrumServerId) ??
         nodeSource.values.firstWhereOrNull((e) => e.uriRaw == cakeWalletLitecoinElectrumUri);
+    final digibyteElectrumServer = nodeSource.get(digibyteElectrumServerId) ??
+        nodeSource.values.firstWhereOrNull((e) => e.uriRaw == cakeWalletDigibyteElectrumUri);
     final ethereumNode = nodeSource.get(ethereumNodeId) ??
         nodeSource.values.firstWhereOrNull((e) => e.uriRaw == ethereumDefaultNodeUri);
     final polygonNode = nodeSource.get(polygonNodeId) ??
@@ -1127,6 +1145,10 @@ abstract class SettingsStoreBase with Store {
 
     if (litecoinElectrumServer != null) {
       nodes[WalletType.litecoin] = litecoinElectrumServer;
+    }
+
+    if (digibyteElectrumServer != null) {
+      nodes[WalletType.digibyte] = digibyteElectrumServer;
     }
 
     if (ethereumNode != null) {
@@ -1336,6 +1358,7 @@ abstract class SettingsStoreBase with Store {
       initialBitcoinTransactionPriority: bitcoinTransactionPriority,
       initialHavenTransactionPriority: havenTransactionPriority,
       initialLitecoinTransactionPriority: litecoinTransactionPriority,
+      initialDigibyteTransactionPriority: digibyteTransactionPriority,
       initialBitcoinCashTransactionPriority: bitcoinCashTransactionPriority,
       initialDecredTransactionPriority: decredTransactionPriority,
       initialShouldRequireTOTP2FAForAccessingWallet: shouldRequireTOTP2FAForAccessingWallet,
@@ -1391,6 +1414,11 @@ abstract class SettingsStoreBase with Store {
         sharedPreferences.getInt(PreferencesKey.litecoinTransactionPriority) != null) {
       priority[WalletType.litecoin] = bitcoin!.deserializeLitecoinTransactionPriority(
           sharedPreferences.getInt(PreferencesKey.litecoinTransactionPriority)!);
+    }
+    if (bitcoin != null &&
+        sharedPreferences.getInt(PreferencesKey.digibyteTransactionPriority) != null) {
+      priority[WalletType.digibyte] = bitcoin!.deserializeLitecoinTransactionPriority(
+          sharedPreferences.getInt(PreferencesKey.digibyteTransactionPriority)!);
     }
     if (ethereum != null &&
         sharedPreferences.getInt(PreferencesKey.ethereumTransactionPriority) != null) {
@@ -1517,6 +1545,8 @@ abstract class SettingsStoreBase with Store {
         sharedPreferences.getInt(PreferencesKey.currentBitcoinElectrumSererIdKey);
     final litecoinElectrumServerId =
         sharedPreferences.getInt(PreferencesKey.currentLitecoinElectrumSererIdKey);
+    final digibyteElectrumServerId =
+        sharedPreferences.getInt(PreferencesKey.currentDigibyteElectrumSererIdKey);
     final bitcoinCashElectrumServerId =
         sharedPreferences.getInt(PreferencesKey.currentBitcoinCashNodeIdKey);
     final havenNodeId = sharedPreferences.getInt(PreferencesKey.currentHavenNodeIdKey);
@@ -1531,6 +1561,7 @@ abstract class SettingsStoreBase with Store {
     final moneroNode = nodeSource.get(nodeId);
     final bitcoinElectrumServer = nodeSource.get(bitcoinElectrumServerId);
     final litecoinElectrumServer = nodeSource.get(litecoinElectrumServerId);
+    final digibyteElectrumServer = nodeSource.get(digibyteElectrumServerId);
     final havenNode = nodeSource.get(havenNodeId);
     final ethereumNode = nodeSource.get(ethereumNodeId);
     final polygonNode = nodeSource.get(polygonNodeId);
@@ -1702,6 +1733,10 @@ abstract class SettingsStoreBase with Store {
       case WalletType.litecoin:
         await _sharedPreferences.setInt(
             PreferencesKey.currentLitecoinElectrumSererIdKey, node.key as int);
+        break;
+      case WalletType.digibyte:
+        await _sharedPreferences.setInt(
+            PreferencesKey.currentDigibyteElectrumSererIdKey, node.key as int);
         break;
       case WalletType.monero:
         await _sharedPreferences.setInt(PreferencesKey.currentNodeIdKey, node.key as int);


### PR DESCRIPTION
## Summary
- add DigiByte constants for node id and tx priority
- extend `WalletType` with DigiByte
- load/save DigiByte node selections and transaction priority
- handle DigiByte in default node lookup

## Testing
- `flutter test` *(fails: flutter not installed)*