### PR TITLE
Add Digibyte config option for Cake Wallet

### DIFF
--- a/scripts/android/pubspec_gen.sh
+++ b/scripts/android/pubspec_gen.sh
@@ -10,7 +10,7 @@ case $APP_ANDROID_TYPE in
                 CONFIG_ARGS="--monero"
                 ;;
         $CAKEWALLET)
-                CONFIG_ARGS="--monero --bitcoin --ethereum --polygon --nano --bitcoinCash --solana --tron --wownero --zano --decred"
+                CONFIG_ARGS="--monero --bitcoin --ethereum --polygon --nano --bitcoinCash --solana --tron --wownero --zano --decred --digibyte"
                 ;;
 esac
 

--- a/scripts/ios/app_config.sh
+++ b/scripts/ios/app_config.sh
@@ -31,8 +31,8 @@ case $APP_IOS_TYPE in
 		;;
 
         $CAKEWALLET)
-		CONFIG_ARGS="--monero --bitcoin --ethereum --polygon --nano --bitcoinCash --solana --tron --wownero --zano --decred"
-		;;
+                CONFIG_ARGS="--monero --bitcoin --ethereum --polygon --nano --bitcoinCash --solana --tron --wownero --zano --decred --digibyte"
+                ;;
 esac
 
 cp -rf pubspec_description.yaml pubspec.yaml

--- a/scripts/macos/app_config.sh
+++ b/scripts/macos/app_config.sh
@@ -36,7 +36,7 @@ case $APP_MACOS_TYPE in
         $MONERO_COM)
 		CONFIG_ARGS="--monero";;
         $CAKEWALLET)
-		CONFIG_ARGS="--monero --bitcoin --ethereum --polygon --nano --bitcoinCash --solana --tron --wownero";;
+                CONFIG_ARGS="--monero --bitcoin --ethereum --polygon --nano --bitcoinCash --solana --tron --wownero --digibyte";;
 esac
 
 cp -rf pubspec_description.yaml pubspec.yaml


### PR DESCRIPTION
## Summary
- update configuration scripts to include Digibyte for Cake Wallet

## Testing
- `dart format --output=none --set-exit-if-changed scripts/android/pubspec_gen.sh scripts/ios/app_config.sh scripts/macos/app_config.sh` *(fails: `dart` not installed)*