### PR TITLE
Enable DigiByte pair defaults

### DIFF
--- a/lib/view_model/exchange/exchange_view_model.dart
+++ b/lib/view_model/exchange/exchange_view_model.dart
@@ -779,6 +779,10 @@ abstract class ExchangeViewModelBase extends WalletChangeListenerViewModel with 
         depositCurrency = CryptoCurrency.dcr;
         receiveCurrency = CryptoCurrency.xmr;
         break;
+      case WalletType.digibyte:
+        depositCurrency = CryptoCurrency.digibyte;
+        receiveCurrency = CryptoCurrency.xmr;
+        break;
       case WalletType.none:
         break;
     }


### PR DESCRIPTION
## Summary
- add DigiByte case to `_initialPairBasedOnWallet`

## Testing
- `dart` and `flutter` commands not available in this environment