### PR TITLE
Add Digibyte URI support

### DIFF
--- a/lib/view_model/wallet_address_list/wallet_address_list_view_model.dart
+++ b/lib/view_model/wallet_address_list/wallet_address_list_view_model.dart
@@ -106,6 +106,21 @@ class LitecoinURI extends PaymentURI {
   }
 }
 
+class DigibyteURI extends PaymentURI {
+  DigibyteURI({required super.amount, required super.address});
+
+  @override
+  String toString() {
+    var base = 'digibyte:$address';
+
+    if (amount.isNotEmpty) {
+      base += '?amount=${amount.replaceAll(',', '.')}';
+    }
+
+    return base;
+  }
+}
+
 class EthereumURI extends PaymentURI {
   EthereumURI({required super.amount, required super.address});
 
@@ -344,6 +359,8 @@ abstract class WalletAddressListViewModelBase extends WalletChangeListenerViewMo
          return ZanoURI(amount: amount, address: address.address);
       case WalletType.decred:
         return DecredURI(amount: amount, address: address.address);
+      case WalletType.digibyte:
+        return DigibyteURI(amount: amount, address: address.address);
       case WalletType.none:
         throw Exception('Unexpected type: ${type.toString()}');
     }


### PR DESCRIPTION
## Summary
- extend `PaymentURI` with a new `DigibyteURI`
- return `DigibyteURI` for `WalletType.digibyte` in `WalletAddressListViewModel`

## Testing
- `dart format` *(fails: `command not found`)*