### PR TITLE
Add DigiByte to balance & explorer URLs

### DIFF
--- a/lib/view_model/dashboard/balance_view_model.dart
+++ b/lib/view_model/dashboard/balance_view_model.dart
@@ -172,6 +172,8 @@ abstract class BalanceViewModelBase with Store {
       case WalletType.nano:
       case WalletType.banano:
         return S.current.receivable_balance;
+      case WalletType.digibyte:
+        return S.current.unconfirmed;
       default:
         return S.current.unconfirmed;
     }
@@ -308,6 +310,8 @@ abstract class BalanceViewModelBase with Store {
       case WalletType.zano:
       case WalletType.decred:
         return true;
+      case WalletType.digibyte:
+        return false;
       default:
         return false;
     }

--- a/lib/view_model/transaction_details_view_model.dart
+++ b/lib/view_model/transaction_details_view_model.dart
@@ -173,6 +173,8 @@ abstract class TransactionDetailsViewModelBase with Store {
         return 'https://blockchair.com/litecoin/transaction/${txId}';
       case WalletType.bitcoinCash:
         return 'https://blockchair.com/bitcoin-cash/transaction/${txId}';
+      case WalletType.digibyte:
+        return 'https://blockchair.com/digibyte/transaction/${txId}';
       case WalletType.haven:
         return 'https://explorer.havenprotocol.org/search?value=${txId}';
       case WalletType.ethereum:
@@ -206,6 +208,8 @@ abstract class TransactionDetailsViewModelBase with Store {
         return S.current.view_transaction_on + 'mempool.space';
       case WalletType.litecoin:
       case WalletType.bitcoinCash:
+        return S.current.view_transaction_on + 'Blockchair.com';
+      case WalletType.digibyte:
         return S.current.view_transaction_on + 'Blockchair.com';
       case WalletType.haven:
         return S.current.view_transaction_on + 'explorer.havenprotocol.org';


### PR DESCRIPTION
## Summary
- handle DigiByte balance display the same as other Bitcoin-type wallets
- link DigiByte transactions to Blockchair

## Testing
- `dart format` *(fails: command not found)*
- `flutter test` *(fails: command not found)*