### PR TITLE
Add digibyte URL schemes

### DIFF
--- a/android/app/src/main/AndroidManifestBase.xml
+++ b/android/app/src/main/AndroidManifestBase.xml
@@ -103,6 +103,9 @@
                 <data android:scheme="decred" />
                 <data android:scheme="decred-wallet" />
                 <data android:scheme="decred_wallet" />
+                <data android:scheme="digibyte" />
+                <data android:scheme="digibyte-wallet" />
+                <data android:scheme="digibyte_wallet" />
             </intent-filter>
             <!-- nano-gpt link scheme -->
             <intent-filter android:autoVerify="true">

--- a/ios/Runner/InfoBase.plist
+++ b/ios/Runner/InfoBase.plist
@@ -282,6 +282,26 @@
                 <string>decred-wallet</string>
             </array>
         </dict>
+        <dict>
+            <key>CFBundleTypeRole</key>
+            <string>Viewer</string>
+            <key>CFBundleURLName</key>
+            <string>digibyte</string>
+            <key>CFBundleURLSchemes</key>
+            <array>
+                <string>digibyte</string>
+            </array>
+        </dict>
+        <dict>
+            <key>CFBundleTypeRole</key>
+            <string>Viewer</string>
+            <key>CFBundleURLName</key>
+            <string>digibyte-wallet</string>
+            <key>CFBundleURLSchemes</key>
+            <array>
+                <string>digibyte-wallet</string>
+            </array>
+        </dict>
     </array>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>


### PR DESCRIPTION
## Summary
- register `digibyte` and `digibyte-wallet` deep link schemes for iOS
- support `digibyte` schemes in Android manifest

## Testing
- `flutter --version` *(fails: command not found)*