### PR TITLE
Fix duplicate cryptocurrency listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ Cake Wallet includes support for several cryptocurrencies, including:
 * DigiByte (DGB)
 * Decred (DCR)
 * Wownero (WOW)
-* DigiByte (DGB)
 
 ## Features
 


### PR DESCRIPTION
## Summary
- remove duplicate DigiByte listing from README

## Testing
- `flutter test` *(fails: `flutter: command not found`)*