### PR TITLE
Fix duplicate digibyteTransactionPriority

### DIFF
--- a/lib/entities/preferences_key.dart
+++ b/lib/entities/preferences_key.dart
@@ -51,7 +51,6 @@ class PreferencesKey {
   static const ethereumTransactionPriority = 'current_fee_priority_ethereum';
   static const polygonTransactionPriority = 'current_fee_priority_polygon';
   static const bitcoinCashTransactionPriority = 'current_fee_priority_bitcoin_cash';
-  static const digibyteTransactionPriority = 'current_fee_priority_digibyte';
   static const zanoTransactionPriority = 'current_fee_priority_zano';
   static const wowneroTransactionPriority = 'current_fee_priority_wownero';
   static const decredTransactionPriority = 'current_fee_priority_decred';


### PR DESCRIPTION
## Summary
- remove the duplicate `digibyteTransactionPriority` constant in `preferences_key.dart`

## Testing
- `flutter test` *(fails: `flutter: command not found`)*