### PR TITLE
Fix duplicate digibyte node case

### DIFF
--- a/lib/entities/node_list.dart
+++ b/lib/entities/node_list.dart
@@ -43,9 +43,6 @@ Future<List<Node>> loadDefaultNodes(WalletType type) async {
     case WalletType.wownero:
       path = 'assets/wownero_node_list.yml';
       break;
-    case WalletType.digibyte:
-      path = 'assets/digibyte_electrum_server_list.yml';
-      break;
     case WalletType.zano:
       path = 'assets/zano_node_list.yml';
       break;


### PR DESCRIPTION
## Summary
- remove duplicate `WalletType.digibyte` branch from `loadDefaultNodes`

## Testing
- `flutter test` *(fails: command not found)*