### PR TITLE
Fix output.dart missing import

### DIFF
--- a/lib/view_model/send/output.dart
+++ b/lib/view_model/send/output.dart
@@ -11,6 +11,7 @@ import 'package:cake_wallet/src/screens/send/widgets/extract_address_from_parsed
 import 'package:cake_wallet/tron/tron.dart';
 import 'package:cake_wallet/wownero/wownero.dart';
 import 'package:cake_wallet/zano/zano.dart';
+import 'package:cake_wallet/digibyte/digibyte.dart';
 import 'package:cw_core/crypto_currency.dart';
 import 'package:cw_core/utils/print_verbose.dart';
 import 'package:flutter/material.dart';


### PR DESCRIPTION
## Summary
- add DigiByte import in `lib/view_model/send/output.dart`

## Testing
- `flutter --version` *(fails: command not found)*