### PR TITLE
Add DigiByte node support

### DIFF
--- a/cw_core/lib/node.dart
+++ b/cw_core/lib/node.dart
@@ -95,6 +95,7 @@ class Node extends HiveObject with Keyable {
       case WalletType.bitcoin:
       case WalletType.litecoin:
       case WalletType.bitcoinCash:
+      case WalletType.digibyte:
         return createUriFromElectrumAddress(uriRaw, path!);
       case WalletType.nano:
       case WalletType.banano:
@@ -158,14 +159,15 @@ class Node extends HiveObject with Keyable {
         case WalletType.nano:
         case WalletType.banano:
           return requestNanoNode();
-        case WalletType.bitcoin:
-        case WalletType.litecoin:
-        case WalletType.bitcoinCash:
-        case WalletType.ethereum:
-        case WalletType.polygon:
-        case WalletType.solana:
-        case WalletType.tron:
-          return requestElectrumServer();
+      case WalletType.bitcoin:
+      case WalletType.litecoin:
+      case WalletType.bitcoinCash:
+      case WalletType.digibyte:
+      case WalletType.ethereum:
+      case WalletType.polygon:
+      case WalletType.solana:
+      case WalletType.tron:
+        return requestElectrumServer();
         case WalletType.zano:
           return requestZanoNode();
         case WalletType.decred:


### PR DESCRIPTION
## Summary
- support DigiByte electrum nodes in `Node.uri`
- connect to DigiByte electrum nodes when requesting a node

## Testing
- `dart --version` *(fails: command not found)*