### PR TITLE
Move Digibyte wallet static methods into class

### DIFF
--- a/cw_digibyte/lib/digibyte_wallet.dart
+++ b/cw_digibyte/lib/digibyte_wallet.dart
@@ -77,7 +77,6 @@ abstract class DigibyteWalletBase extends ElectrumWallet with Store {
     BitcoinOrdering outputOrdering = BitcoinOrdering.bip69,
   }) =>
       throw UnimplementedError();
-}
 
   static Future<DigibyteWallet> create({
     required String mnemonic,


### PR DESCRIPTION
## Summary
- move `create` and `open` into `DigibyteWalletBase`

## Testing
- `bash model_generator.sh cw_digibyte` *(fails: `flutter: command not found`)*