### PR TITLE
Add digibyte cases for wallet type switches

### DIFF
--- a/lib/core/wallet_creation_service.dart
+++ b/lib/core/wallet_creation_service.dart
@@ -77,6 +77,7 @@ class WalletCreationService {
     switch (type) {
       case WalletType.bitcoin:
       case WalletType.litecoin:
+      case WalletType.digibyte:
       case WalletType.bitcoinCash:
       case WalletType.ethereum:
       case WalletType.polygon:

--- a/lib/entities/priority_for_wallet_type.dart
+++ b/lib/entities/priority_for_wallet_type.dart
@@ -19,6 +19,8 @@ List<TransactionPriority> priorityForWalletType(WalletType type) {
       return bitcoin!.getTransactionPriorities();
     case WalletType.litecoin:
       return bitcoin!.getLitecoinTransactionPriorities();
+    case WalletType.digibyte:
+      return bitcoin!.getLitecoinTransactionPriorities();
     case WalletType.ethereum:
       return ethereum!.getTransactionPriorities();
     case WalletType.bitcoinCash:

--- a/lib/reactions/bip39_wallet_utils.dart
+++ b/lib/reactions/bip39_wallet_utils.dart
@@ -8,6 +8,7 @@ bool isBIP39Wallet(WalletType walletType) {
     case WalletType.tron:
     case WalletType.bitcoin:
     case WalletType.litecoin:
+    case WalletType.digibyte:
     case WalletType.bitcoinCash:
     case WalletType.nano:
     case WalletType.banano:

--- a/lib/src/screens/dashboard/desktop_widgets/desktop_wallet_selection_dropdown.dart
+++ b/lib/src/screens/dashboard/desktop_widgets/desktop_wallet_selection_dropdown.dart
@@ -37,6 +37,7 @@ class _DesktopWalletSelectionDropDownState extends State<DesktopWalletSelectionD
   final bitcoinIcon = Image.asset('assets/images/bitcoin.png', height: 24, width: 24);
   final tBitcoinIcon = Image.asset('assets/images/tbtc.png', height: 24, width: 24);
   final litecoinIcon = Image.asset('assets/images/litecoin_icon.png', height: 24, width: 24);
+  final digibyteIcon = Image.asset('assets/images/digibyte.png', height: 24, width: 24);
   final havenIcon = Image.asset('assets/images/haven_logo.png', height: 24, width: 24);
   final ethereumIcon = Image.asset('assets/images/eth_icon.png', height: 24, width: 24);
   final polygonIcon = Image.asset('assets/images/matic_icon.png', height: 24, width: 24);
@@ -164,6 +165,8 @@ class _DesktopWalletSelectionDropDownState extends State<DesktopWalletSelectionD
         return wowneroIcon;
       case WalletType.litecoin:
         return litecoinIcon;
+      case WalletType.digibyte:
+        return digibyteIcon;
       case WalletType.haven:
         return havenIcon;
       case WalletType.ethereum:

--- a/lib/src/screens/dashboard/widgets/menu_widget.dart
+++ b/lib/src/screens/dashboard/widgets/menu_widget.dart
@@ -39,7 +39,8 @@ class MenuWidgetState extends State<MenuWidget> {
         this.tronIcon = Image.asset('assets/images/trx_icon.png'),
         this.wowneroIcon = Image.asset('assets/images/wownero_icon.png'),
         this.zanoIcon = Image.asset('assets/images/zano_icon.png'),
-        this.decredIcon = Image.asset('assets/images/decred_menu.png');
+        this.decredIcon = Image.asset('assets/images/decred_menu.png'),
+        this.digibyteIcon = Image.asset('assets/images/digibyte.png');
 
   final largeScreen = 731;
 
@@ -55,6 +56,7 @@ class MenuWidgetState extends State<MenuWidget> {
   Image moneroIcon;
   Image bitcoinIcon;
   Image litecoinIcon;
+  Image digibyteIcon;
   Image havenIcon;
   Image ethereumIcon;
   Image bitcoinCashIcon;
@@ -232,6 +234,8 @@ class MenuWidgetState extends State<MenuWidget> {
         return bitcoinIcon;
       case WalletType.litecoin:
         return litecoinIcon;
+      case WalletType.digibyte:
+        return digibyteIcon;
       case WalletType.haven:
         return havenIcon;
       case WalletType.ethereum:

--- a/lib/view_model/advanced_privacy_settings_view_model.dart
+++ b/lib/view_model/advanced_privacy_settings_view_model.dart
@@ -44,6 +44,7 @@ abstract class AdvancedPrivacySettingsViewModelBase with Store {
 
       case WalletType.bitcoin:
       case WalletType.litecoin:
+      case WalletType.digibyte:
         return _settingsStore.bitcoinSeedType == BitcoinSeedType.bip39;
 
       case WalletType.nano:

--- a/lib/view_model/wallet_new_vm.dart
+++ b/lib/view_model/wallet_new_vm.dart
@@ -76,6 +76,7 @@ abstract class WalletNewVMBase extends WalletCreationVM with Store {
         );
       case WalletType.bitcoin:
       case WalletType.litecoin:
+      case WalletType.digibyte:
         return bitcoin!.createBitcoinNewWalletCredentials(
           name: name,
           password: walletPassword,


### PR DESCRIPTION
## Summary
- handle `WalletType.digibyte` in wallet utilities and services
- include digibyte icon in UI menu widgets
- update switch statements to avoid missing DigiByte cases

## Testing
- `dart format` *(fails: `dart: command not found`)*