### PR TITLE
Fix digibyte wallet service constructor

### DIFF
--- a/cw_digibyte/lib/digibyte_wallet_service.dart
+++ b/cw_digibyte/lib/digibyte_wallet_service.dart
@@ -46,7 +46,7 @@ class DigibyteWalletService extends WalletService<
         break;
     }
 
-    final wallet = await DigibyteWalletBase(
+    final wallet = await DigibyteWalletBase.create(
       mnemonic: mnemonic,
       password: credentials.password!,
       passphrase: credentials.passphrase,
@@ -168,7 +168,7 @@ class DigibyteWalletService extends WalletService<
       throw DigibyteMnemonicIsIncorrectException();
     }
 
-    final wallet = await DigibyteWalletBase(
+    final wallet = await DigibyteWalletBase.create(
       password: credentials.password!,
       passphrase: credentials.passphrase,
       mnemonic: credentials.mnemonic,


### PR DESCRIPTION
## Summary
- use `DigibyteWalletBase.create` when creating or restoring wallets

## Testing
- `git status --short`