### PR TITLE
Fix duplicate cw_digibyte dependency

### DIFF
--- a/pubspec_base.yaml
+++ b/pubspec_base.yaml
@@ -126,8 +126,6 @@ dependencies:
       url: https://github.com/MrCyjaneK/flutter_daemon
       ref: 6d5270d64b5dd588fce12fd0a0c7314c37e6cff1
   flutter_local_notifications: ^19.0.0
-  cw_digibyte:
-    path: ./cw_digibyte
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- avoid duplicate `cw_digibyte` entry in generated `pubspec.yaml`

## Testing
- `flutter --version` *(fails: command not found)*