### PR TITLE
Use bitcoin utilities wrapper for Digibyte

### DIFF
--- a/lib/digibyte/digibyte.dart
+++ b/lib/digibyte/digibyte.dart
@@ -1,0 +1,14 @@
+import 'package:cw_core/wallet_credentials.dart';
+import 'package:cw_core/wallet_info.dart';
+import 'package:cw_core/wallet_service.dart';
+import 'package:cw_core/transaction_priority.dart';
+import 'package:cw_core/unspent_coins_info.dart';
+import 'package:hive/hive.dart';
+import 'package:cw_digibyte/cw_digibyte.dart';
+import '../../src/bitcoin_utilities.dart';
+
+part 'cw_digibyte.dart';
+
+Digibyte? digibyte = CWDigibyte();
+
+abstract class Digibyte {}

--- a/src/bitcoin_utilities.dart
+++ b/src/bitcoin_utilities.dart
@@ -1,0 +1,6 @@
+// src/bitcoin_utilities.dart
+export 'package:cw_bitcoin/electrum_derivations.dart'
+    show DerivationType, electrum_path;
+export 'package:cw_bitcoin/bitcoin_wallet_creation_credentials.dart';
+export 'package:cw_bitcoin/bitcoin_transaction_priority.dart';
+export 'package:cw_bitcoin/bitcoin_transaction_credentials.dart';


### PR DESCRIPTION
## Summary
- add a bitcoin utilities export wrapper
- refactor Digibyte imports to use the wrapper

## Testing
- `dart format lib/digibyte/digibyte.dart src/bitcoin_utilities.dart` *(fails: `dart: command not found`)*
- `flutter analyze` *(fails: `flutter: command not found`)*