### PR TITLE
Document DigiByte Ledger limitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ Cake Wallet includes support for several cryptocurrencies, including:
 * Create donation links and invoices in the receive screen
 * Robust privacy settings (eg: Tor-only connections)
 * Robust security settings (eg: Cake 2FA)
+* Ledger hardware wallet support for Bitcoin, Litecoin, and Ethereum
+  (DigiByte hardware wallets are currently unsupported)
 
 ### Monero Specific Features
 

--- a/cw_digibyte/lib/digibyte_wallet.dart
+++ b/cw_digibyte/lib/digibyte_wallet.dart
@@ -61,7 +61,8 @@ abstract class DigibyteWalletBase extends ElectrumWallet with Store {
 
   @override
   void setLedgerConnection(LedgerConnection connection) {
-    // DigiByte hardware wallet support is not implemented
+    throw UnimplementedError(
+        'Hardware wallet support for DigiByte is not implemented');
   }
 
   @override
@@ -76,7 +77,8 @@ abstract class DigibyteWalletBase extends ElectrumWallet with Store {
     BitcoinOrdering inputOrdering = BitcoinOrdering.bip69,
     BitcoinOrdering outputOrdering = BitcoinOrdering.bip69,
   }) =>
-      throw UnimplementedError();
+      throw UnimplementedError(
+          'Hardware wallet support for DigiByte is not implemented');
 
   static Future<DigibyteWallet> create({
     required String mnemonic,


### PR DESCRIPTION
## Summary
- clarify that DigiByte does not yet support hardware wallets
- throw UnimplementedError for DigiByte Ledger methods

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6846b3ceda30832b8b1b83a849336fdd