### PR TITLE
Implement digibyte restore from WIF

### DIFF
--- a/cw_digibyte/test/digibyte_wallet_test.dart
+++ b/cw_digibyte/test/digibyte_wallet_test.dart
@@ -7,6 +7,9 @@ import 'package:cw_core/wallet_base.dart';
 import 'package:cw_core/encryption_file_utils.dart';
 import 'package:hive/hive.dart';
 import 'package:cw_core/crypto_currency.dart';
+import 'package:bitcoin_base/bitcoin_base.dart';
+import 'package:cw_bitcoin/utils.dart';
+import 'dart:typed_data';
 
 void main() {
   group('DigibyteWallet', () {
@@ -45,6 +48,57 @@ void main() {
       expect(wallet.walletInfo.type, WalletType.digibyte);
       expect(wallet.balance[CryptoCurrency.digibyte]?.confirmed, 0);
       expect(wallet.balance[CryptoCurrency.digibyte]?.unconfirmed, 0);
+      await walletInfoBox.close();
+      await unspentCoinsBox.close();
+    });
+
+    test('Restore from WIF', () async {
+      final walletInfoBox = await Hive.openBox<WalletInfo>('walletInfo');
+      final unspentCoinsBox = await Hive.openBox<UnspentCoinsInfo>('unspentCoins');
+
+      final walletInfo = WalletInfo.external(
+        id: WalletBase.idFor('wif_wallet', WalletType.digibyte),
+        name: 'wif_wallet',
+        type: WalletType.digibyte,
+        isRecovery: true,
+        restoreHeight: 0,
+        date: DateTime.now(),
+        path: '',
+        dirPath: '',
+        address: '',
+      );
+
+      final priv = List<int>.filled(32, 1);
+      final wif =
+          WifEncoder.encode(priv, netVer: DigibyteNetwork.mainnet.wifNetVer);
+
+      final credentials = BitcoinRestoreWalletFromWIFCredentials(
+        name: 'wif_wallet',
+        password: 'test',
+        wif: wif,
+        walletInfo: walletInfo,
+      );
+
+      final service = DigibyteWalletService(
+        walletInfoBox,
+        unspentCoinsBox,
+        false,
+        true,
+      );
+
+      final wallet = await service.restoreFromKeys(credentials);
+
+      final hd = Bip32Slip10Secp256k1.fromSeed(Uint8List.fromList(priv))
+          .derivePath(electrum_path) as Bip32Slip10Secp256k1;
+
+      final expected = generateP2WPKHAddress(
+        hd: hd,
+        index: 0,
+        network: DigibyteNetwork.mainnet,
+      );
+
+      expect(wallet.walletAddresses.address, expected);
+
       await walletInfoBox.close();
       await unspentCoinsBox.close();
     });


### PR DESCRIPTION
## Summary
- implement `restoreFromKeys` for digibyte service
- add unit test for restoring a digibyte wallet from WIF

## Testing
- `flutter test cw_digibyte/test/digibyte_wallet_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6846b3d171b0832bbdf4b5fa0a959dca