### PR TITLE
Clarify optional Decred support

### DIFF
--- a/docs/builds/ANDROID.md
+++ b/docs/builds/ANDROID.md
@@ -26,7 +26,9 @@ pushd scripts/android
     # source ./app_env.sh monero.com # Uncomment this line to build monero.com
     ./app_config.sh
     ./build_monero_all.sh
+    # Optional: generate Decred bindings if support is needed
     ./build_decred.sh
+    # If skipping Decred, remove or comment the `cw_decred` dependency from the generated pubspec.yaml
     ./build_mwebd.sh --dont-install
 popd
 pushd android/app

--- a/docs/builds/IOS.md
+++ b/docs/builds/IOS.md
@@ -101,7 +101,9 @@ Build the necessary libraries and their dependencies:
 ```zsh
 ./build_monero_all.sh
 ./build_mwebd.sh
+# Optional: generate Decred bindings if support is needed
 ./build_decred.sh
+# If skipping Decred, remove or comment the `cw_decred` dependency from the generated pubspec.yaml
 ```
 
 NOTE: This step will take quite a while, so be sure you grab a cup of coffee or a good book!

--- a/docs/builds/MACOS.md
+++ b/docs/builds/MACOS.md
@@ -93,7 +93,9 @@ Build the necessary libraries and their dependencies:
 
 ```zsh
 ./build_monero_all.sh
+# Optional: generate Decred bindings if support is needed
 ./build_decred.sh
+# If skipping Decred, remove or comment the `cw_decred` dependency from the generated pubspec.yaml
 ```
 
 NOTE: This step will take quite a while, so be sure you grab a cup of coffee or a good book!


### PR DESCRIPTION
## Summary
- mention that `build_decred.sh` is optional
- note how to disable Decred by removing `cw_decred` from pubspec

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68495b2f0960832b9b43cf7ef35e3cec