### PR TITLE
Fix duplicate case in SSL update logic

### DIFF
--- a/lib/entities/default_settings_migration.dart
+++ b/lib/entities/default_settings_migration.dart
@@ -647,7 +647,6 @@ Future<void> _fixNodesUseSSLFlag(Box<Node> nodes) async {
       case cakeWalletDigibyteElectrumUri:
       case cakeWalletBitcoinElectrumUri:
       case newCakeWalletBitcoinUri:
-      case cakeWalletDigibyteElectrumUri:
       case newCakeWalletMoneroUri:
         node.useSSL = true;
         node.trusted = true;


### PR DESCRIPTION
## Summary
- remove duplicate `cakeWalletDigibyteElectrumUri` case inside `_fixNodesUseSSLFlag`
- run formatter

## Testing
- `dart format lib/entities/default_settings_migration.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684963fa39c8832b836e616396ef0fb6