### PR TITLE
Fix configure script to generate models

### DIFF
--- a/configure_cake_wallet.sh
+++ b/configure_cake_wallet.sh
@@ -37,5 +37,5 @@ source ./app_env.sh cakewallet
 ./app_config.sh
 cd ../.. && flutter pub get
 dart run tool/generate_localization.dart
-#./model_generator.sh
+./model_generator.sh
 #cd macos && pod install


### PR DESCRIPTION
## Summary
- ensure `configure_cake_wallet.sh` runs `model_generator.sh` so packages generate `*.g.dart` files automatically

## Testing
- `./configure_cake_wallet.sh ios` *(fails: `/usr/libexec/PlistBuddy: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_b_684ac48b1778832bb7eac991e14dd83e