### PR TITLE
Fix build by including Bitcoin when Digibyte is enabled

### DIFF
--- a/tool/configure.dart
+++ b/tool/configure.dart
@@ -1534,7 +1534,7 @@ Future<void> generatePubspec({
     output += '\n$cwMonero';
   }
 
-  if (hasBitcoin) {
+  if (hasBitcoin || hasDigibyte) {
     output += '\n$cwBitcoin';
   }
 


### PR DESCRIPTION
## Summary
- ensure Digibyte builds also include cw_bitcoin dependency

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6886bdb73340832b8419c55b9e78bb47