### PR TITLE
docs: plan digibyte integration rollout

### DIFF
--- a/assets/digibyte_electrum_server_list.yml
+++ b/assets/digibyte_electrum_server_list.yml
@@ -1,0 +1,13 @@
+-
+  uri: electrum1.digibyte.host:50002
+  is_default: true
+  useSSL: true
+  isEnabledForAutoSwitching: true
+-
+  uri: electrum2.digibyte.host:50002
+  useSSL: true
+  isEnabledForAutoSwitching: true
+-
+  uri: dgb-cn1.electrum.digibyte.io:50002
+  useSSL: true
+  isEnabledForAutoSwitching: true

--- a/docs/dgb_listing_requirements.md
+++ b/docs/dgb_listing_requirements.md
@@ -1,0 +1,66 @@
+# DigiByte (DGB) Listing Package for Cake Wallet
+
+This document captures the information Cake Wallet typically requires when assessing a new asset listing request. It collates the core data for DigiByte (DGB) and highlights any remaining gaps that should be resolved before submitting the listing application.
+
+## 1. Asset Overview
+
+| Field | Details |
+| --- | --- |
+| Asset name | DigiByte |
+| Ticker | DGB |
+| Asset type | Native UTXO blockchain (Bitcoin-codebase derivative) |
+| Launch date | 10 January 2014 |
+| Website | https://digibyte.org |
+| Whitepaper | https://digibyte.org/whitepaper |
+| Open-source repository | https://github.com/DigiByte-Core/digibyte |
+| License | MIT (inherits Bitcoin Core licensing) |
+| Logo | `assets/images/digibyte.png` (already present in repository) |
+| Supported decimals | 8 (matches `CryptoCurrency.digibyte` entry) |
+| BIP44 coin type | 20 |
+| Block explorers | https://digiexplorer.info, https://chainz.cryptoid.info/dgb/, https://dgb.tokenview.com/en |
+| Social / community | https://twitter.com/DigiByteCoin, https://t.me/DigiByteCoin |
+
+## 2. Technical Parameters
+
+* **Consensus:** MultiShield Proof-of-Work employing five algorithms (SHA-256, Scrypt, Skein, Groestl, and Qubit) with real-time difficulty adjustment.
+* **Average block time:** ~15 seconds (a new block from each algorithm roughly every 75 seconds).
+* **Maximum supply:** 21,000,000,000 DGB (scheduled to be reached around 2035).
+* **Emission schedule:** Block reward decreases by 1% every month; no premine or ICO.
+* **SegWit & address formats:** Supports legacy P2PKH (`D...`), P2SH (`3...`), and bech32 SegWit (`dgb1...`).
+* **Transaction fees:** Bitcoin-style fee market denominated in satoshis per byte; SegWit adoption keeps typical fees below a few cents at 1–2 sat/byte.
+* **BIP32 path:** `m/44'/20'/account'/change/index` for legacy, `49'` and `84'` variations for nested SegWit and native SegWit derivations respectively.
+* **Network ports:** Default P2P port `12024`, default RPC port `14022` (configurable).
+
+## 3. Network Infrastructure & Wallet Compatibility
+
+* **Reference full node implementation:** `digibyted` (from the DigiByte Core repository). Supports JSON-RPC identical to Bitcoin Core; Cake Wallet integration can reuse existing Bitcoin RPC abstractions with chain-specific parameters (coin type 120 and message start string adjustments).
+* **Public JSON-RPC endpoints for initial testing:**
+  * `https://digiexplorer.info/api` (read-only REST for quick testing, not a full RPC substitute).
+  * Community-hosted RPC nodes are available through the DigiByte Alliance; production integration is expected to run Cake-hosted nodes for reliability. (Action item: confirm which internally managed nodes can be exposed.)
+* **Electrum ecosystem:** DigiByte supports ElectrumX servers for light clients. Known community-maintained SSL servers include `electrum1.digibyte.host:50002`, `electrum2.digibyte.host:50002`, and `dgb-cn1.electrum.digibyte.io:50002`. These should be validated and mirrored in a new `assets/digibyte_electrum_server_list.yml` during implementation.
+* **Existing wallet integrations:** DigiByte is already supported by hardware (Ledger via Electrum, Trezor), mobile (Trust Wallet, Coinomi, Edge, Exodus), and desktop (DigiByte Core, Atomic). This demonstrates mature third-party support and mature tooling.
+
+## 4. Security, Compliance, and Maintenance
+
+* **Security model:** Open-source, audited codebase with nearly a decade of production history and broad community node distribution (>300,000 full nodes historically reported). MultiShield protects against sudden hashrate swings on any algorithm.
+* **Protocol upgrades:** Consensus changes are coordinated by the DigiByte Core developers and DigiByte Awareness Team; improvement proposals are tracked in the `DGBIPs` repository. Recent upgrades focused on SegWit adoption, Odocrypt (for FPGA resistance), and Digi-ID.
+* **Ecosystem governance:** DigiByte is decentralized with no company ownership. The DigiByte Foundation (non-profit) and DigiByte Awareness Team handle outreach. Key contacts: `foundation@digibytefoundation.org` (foundation) and `hello@digibyte.io` (ecosystem coordination).
+* **Regulatory posture:** Pure PoW utility token with no premine/ICO. Trading widely available on regulated exchanges (e.g., Bittrex, Coinbase custody support, KuCoin). No known securities enforcement actions.
+
+## 5. Integration Checklist for Cake Wallet
+
+1. **Wallet type plumbing** – Add a `WalletType.digibyte` entry in `cw_core/lib/wallet_type.dart`, update serialization helpers, and surface the human-readable name in `walletTypeToString`/`walletTypeToDisplayName`.
+2. **Currency configuration** – The DigiByte asset is already declared in `cw_core/lib/crypto_currency.dart` (`CryptoCurrency.digibyte`) with ticker, icon, and 8 decimals. Ensure it is wired to the new wallet type once implemented. 【F:cw_core/lib/crypto_currency.dart†L215-L237】
+3. **Node bootstrapping** – Create an Electrum server list file (e.g., `assets/digibyte_electrum_server_list.yml`) mirroring the structure used for Bitcoin/Dogecoin and load it inside `loadDefaultNodes`/`resetToDefault` in `lib/entities/node_list.dart`.
+4. **Proxy package** – Scaffold a `cw_digibyte` package following the process documented in `docs/NEW_WALLET_TYPES.md` (code generation hooks, proxy wiring, DI registration, etc.). 【F:docs/NEW_WALLET_TYPES.md†L1-L120】
+5. **Node configuration scripts** – Extend Android/iOS/macOS configuration scripts to include the DigiByte flag once the proxy package exists (see Section “Configuration Files Setup” in the same guide).
+6. **Testing** – Sync against mainnet using a trusted node, validate send/receive flows, and ensure exchange integrations display correct decimal handling (8 decimals as per Step 2).
+
+## 6. Outstanding Items / Data to Confirm
+
+* Provide a list of Cake-controlled DigiByte Electrum or RPC nodes (hostname, ports, SSL) for production configuration.
+* Share updated contact details for the technical lead(s) responsible for coordinating with Cake Wallet should protocol updates occur.
+* Confirm whether DigiByte requires any additional derivation paths beyond standard BIP44/49/84 for compatibility with existing user seeds.
+* Supply any marketing collateral (brand guidelines, icon usage rights) if Cake Wallet requires explicit approval for app store submissions.
+
+Once the above confirmations are obtained, this document can accompany the official listing request to Cake Wallet, demonstrating that DigiByte meets the technical and operational expectations for integration.

--- a/docs/dgb_project_plan.md
+++ b/docs/dgb_project_plan.md
@@ -1,0 +1,57 @@
+# DigiByte (DGB) Integration Plan for Cake Wallet
+
+This plan breaks the DigiByte listing effort into implementation phases, ensuring that we stage code changes in the order required by Cake Wallet's architecture. Each phase calls out the artifacts we must add or modify, internal dependencies, and any external resources still needed from the DigiByte team or community.
+
+## Phase 0 – Discovery & Requirements
+- ✅ Confirm existing DigiByte currency metadata in `cw_core/lib/crypto_currency.dart` (ticker, display name, icon, decimals).
+- ☐ Gather canonical Electrum server inventory and uptime data to seed the default node list.
+- ☐ Validate JSON-RPC compatibility (e.g. `digibyted` version, pruning requirements, fee policy) for potential full node support.
+- ☐ Obtain official contacts for escalation (foundation/maintainers) to include with listing submission.
+
+**Resources Needed from DigiByte representatives**
+1. Endorsed Electrum servers (at least three, SSL-enabled) with operator contacts for ongoing maintenance.
+2. Confirmation of minimum node version that Cake Wallet should target.
+3. Guidance on any DigiByte-specific transaction relay quirks (e.g. DigiShield, MultiAlgo) that could affect fee estimation.
+4. Optional: Community-run public RPC endpoints if we decide to surface full-node connectivity.
+
+## Phase 1 – Core Type & Assets
+Goal: teach the shared core about the new wallet type so that UI scaffolding and dependency injection recognize DigiByte.
+
+- [ ] Add `WalletType.digibyte` enum value and update all switch statements (`walletTypeToString`, `walletTypeToDisplayName`, serialization helpers, etc.).
+- [ ] Map DigiByte to its currency via `walletTypeToCryptoCurrency` and `cryptoCurrencyToWalletType`.
+- [ ] Register DigiByte in the generated wallet type lists (`tool/configure.dart`, `scripts/*/app_config.sh`) to unblock proxy generation.
+- [ ] Extend `lib/entities/node_list.dart` to load DigiByte default nodes and ensure `resetToDefault` persists them.
+- [ ] Ship `assets/digibyte_electrum_server_list.yml` and register it in `pubspec_base.yaml`.
+
+## Phase 2 – Node Defaults & Settings Migration
+Goal: guarantee that new installs and migrations receive functional DigiByte nodes.
+
+- [ ] Define DigiByte default node URI constants and helpers in `lib/entities/default_settings_migration.dart` (mirroring Dogecoin).
+- [ ] Wire DigiByte into `addWalletNodeList`, `_changeDefaultNode`, and migration switch cases.
+- [ ] Add persistent storage keys in `lib/entities/preferences_key.dart` for tracking the current DigiByte node.
+
+## Phase 3 – DigiByte Wallet Package (`cw_digibyte`)
+Goal: encapsulate DigiByte Electrum integration in a dedicated package, following the Bitcoin-family architecture.
+
+- [ ] Scaffold `cw_digibyte` package with wallet service, wallet class, address management, transaction priority, etc. (reference `cw_dogecoin`).
+- [ ] Add build scripts (`model_generator.sh`, `scripts/*/app_config.sh`) to include DigiByte package in generated outputs.
+- [ ] Implement DigiByte-specific constants (SLIP44 coin type 20, network magic, address prefixes, fee policy) inside the package.
+- [ ] Provide unit tests that cover balance parsing, transaction decoding, and fee rate calculation for DigiByte.
+
+## Phase 4 – Proxy Wiring & Dependency Injection
+Goal: expose DigiByte functionality to the application layer via generated proxies.
+
+- [ ] Create proxy configuration entries in `tool/configure.dart` and run the generator to produce `lib/digibyte/digibyte.dart`.
+- [ ] Register DigiByte services in dependency injection (`lib/di.dart`) and wallet creation flows (`lib/view_model/wallet_new_vm.dart`, etc.).
+- [ ] Update UI selectors, routing, and localization strings to surface DigiByte in wallet creation/import screens.
+
+## Phase 5 – QA, Documentation & Submission Packet
+Goal: finish the listing packet with test evidence and handoff notes.
+
+- [ ] Document QA checklist results (sync, send, receive on mainnet/testnet if available).
+- [ ] Update `docs/dgb_listing_requirements.md` with final node list, maintainers, and test logs.
+- [ ] Prepare submission summary for Cake Wallet maintainers.
+
+---
+
+Tracking this checklist inside the repository keeps the effort transparent and makes it easy to raise follow-up PRs for each phase. As we progress, we'll convert the checkbox items to ✅ with links to the corresponding commits.


### PR DESCRIPTION
## Summary
- add a phased DigiByte integration plan that enumerates implementation tasks and required external resources
- stage an initial Electrum server inventory file for DigiByte to unblock future node wiring work

## Testing
- not run (docs and data only)


------
https://chatgpt.com/codex/tasks/task_b_68ca8d5a8800832bb5461a571a0d91f8