### PR TITLE
Add DigiByte wallet integration scaffolding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,6 +141,7 @@ lib/wownero/wownero.dart
 lib/zano/zano.dart
 lib/decred/decred.dart
 lib/dogecoin/dogecoin.dart
+lib/digibyte/digibyte.dart
 
 ios/Runner/Assets.xcassets/AppIcon.appiconset/AppIcon@2x.png
 ios/Runner/Assets.xcassets/AppIcon.appiconset/AppIcon@2x~ipad.png

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -23,6 +23,8 @@ analyzer:
     lib/tron/cw_tron.dart,
     lib/wownero/cw_wownero.dart,
     lib/zano/cw_zano.dart,
+    lib/dogecoin/cw_dogecoin.dart,
+    lib/digibyte/cw_digibyte.dart,
     ]
   language:
     strict-casts: true

--- a/cw_digibyte/.gitignore
+++ b/cw_digibyte/.gitignore
@@ -1,0 +1,31 @@
+# Miscellaneous
+*.class
+*.log
+*.pyc
+*.swp
+.DS_Store
+.atom/
+.buildlog/
+.history
+.svn/
+migrate_working_dir/
+
+# IntelliJ related
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# The .vscode folder contains launch configuration and tasks you configure in
+# VS Code which you may wish to be included in version control, so this line
+# is commented out by default.
+#.vscode/
+
+# Flutter/Dart/Pub related
+# Libraries should not include pubspec.lock, per https://dart.dev/guides/libraries/private-files#pubspeclock.
+/pubspec.lock
+**/doc/api/
+.dart_tool/
+.flutter-plugins
+.flutter-plugins-dependencies
+build/

--- a/cw_digibyte/.metadata
+++ b/cw_digibyte/.metadata
@@ -1,0 +1,10 @@
+# This file tracks properties of this Flutter project.
+# Used by Flutter tool to assess capabilities and perform upgrades etc.
+#
+# This file should be version controlled and should not be manually edited.
+
+version:
+  revision: "c23637390482d4cf9598c3ce3f2be31aa7332daf"
+  channel: "stable"
+
+project_type: package

--- a/cw_digibyte/CHANGELOG.md
+++ b/cw_digibyte/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 0.0.1
+
+* TODO: Describe initial release.

--- a/cw_digibyte/LICENSE
+++ b/cw_digibyte/LICENSE
@@ -1,0 +1,1 @@
+TODO: Add your license here.

--- a/cw_digibyte/README.md
+++ b/cw_digibyte/README.md
@@ -1,0 +1,39 @@
+<!--
+This README describes the package. If you publish this package to pub.dev,
+this README's contents appear on the landing page for your package.
+
+For information about how to write a good package README, see the guide for
+[writing package pages](https://dart.dev/tools/pub/writing-package-pages).
+
+For general information about developing packages, see the Dart guide for
+[creating packages](https://dart.dev/guides/libraries/create-packages)
+and the Flutter guide for
+[developing packages and plugins](https://flutter.dev/to/develop-packages).
+-->
+
+TODO: Put a short description of the package here that helps potential users
+know whether this package might be useful for them.
+
+## Features
+
+TODO: List what your package can do. Maybe include images, gifs, or videos.
+
+## Getting started
+
+TODO: List prerequisites and provide or point to information on how to
+start using the package.
+
+## Usage
+
+TODO: Include short and useful examples for package users. Add longer examples
+to `/example` folder.
+
+```dart
+const like = 'sample';
+```
+
+## Additional information
+
+TODO: Tell users more about the package: where to find more information, how to
+contribute to the package, how to file issues, what response they can expect
+from the package authors, and more.

--- a/cw_digibyte/analysis_options.yaml
+++ b/cw_digibyte/analysis_options.yaml
@@ -1,0 +1,4 @@
+include: package:flutter_lints/flutter.yaml
+
+# Additional information about this file can be found at
+# https://dart.dev/guides/language/analysis-options

--- a/cw_digibyte/lib/cw_digibyte.dart
+++ b/cw_digibyte/lib/cw_digibyte.dart
@@ -1,0 +1,6 @@
+export 'src/digibyte_wallet.dart';
+export 'src/digibyte_wallet_addresses.dart';
+export 'src/digibyte_wallet_creation_credentials.dart';
+export 'src/digibyte_wallet_service.dart';
+export 'src/digibyte_transaction_priority.dart';
+

--- a/cw_digibyte/lib/src/digibyte_transaction_priority.dart
+++ b/cw_digibyte/lib/src/digibyte_transaction_priority.dart
@@ -1,0 +1,52 @@
+import 'package:cw_bitcoin/bitcoin_transaction_priority.dart';
+
+class DigibyteTransactionPriority extends BitcoinTransactionPriority {
+  const DigibyteTransactionPriority({required String title, required int raw})
+      : super(title: title, raw: raw);
+
+  static const List<DigibyteTransactionPriority> all = [fast, medium, slow];
+  static const DigibyteTransactionPriority slow =
+      DigibyteTransactionPriority(title: 'Slow', raw: 0);
+  static const DigibyteTransactionPriority medium =
+      DigibyteTransactionPriority(title: 'Medium', raw: 1);
+  static const DigibyteTransactionPriority fast =
+      DigibyteTransactionPriority(title: 'Fast', raw: 2);
+
+  static DigibyteTransactionPriority deserialize({required int raw}) {
+    switch (raw) {
+      case 0:
+        return slow;
+      case 1:
+        return medium;
+      case 2:
+        return fast;
+      default:
+        throw Exception('Unexpected token: $raw for DigibyteTransactionPriority deserialize');
+    }
+  }
+
+  @override
+  String get units => 'sat';
+
+  @override
+  String toString() {
+    var label = '';
+
+    switch (this) {
+      case DigibyteTransactionPriority.slow:
+        label = 'Slow'; // S.current.transaction_priority_slow;
+        break;
+      case DigibyteTransactionPriority.medium:
+        label = 'Medium'; // S.current.transaction_priority_medium;
+        break;
+      case DigibyteTransactionPriority.fast:
+        label = 'Fast'; // S.current.transaction_priority_fast;
+        break;
+      default:
+        break;
+    }
+
+    return label;
+  }
+}
+

--- a/cw_digibyte/lib/src/digibyte_wallet.dart
+++ b/cw_digibyte/lib/src/digibyte_wallet.dart
@@ -1,0 +1,161 @@
+import 'package:bitcoin_base/bitcoin_base.dart';
+import 'package:blockchain_utils/blockchain_utils.dart';
+import 'package:cw_bitcoin/bitcoin_address_record.dart';
+import 'package:cw_bitcoin/bitcoin_mnemonics_bip39.dart';
+import 'package:cw_bitcoin/electrum_balance.dart';
+import 'package:cw_bitcoin/electrum_wallet.dart';
+import 'package:cw_bitcoin/electrum_wallet_snapshot.dart';
+import 'package:cw_core/crypto_currency.dart';
+import 'package:cw_core/encryption_file_utils.dart';
+import 'package:cw_core/unspent_coins_info.dart';
+import 'package:cw_core/wallet_info.dart';
+import 'package:cw_core/wallet_keys_file.dart';
+import 'package:flutter/foundation.dart';
+import 'package:hive/hive.dart';
+import 'package:mobx/mobx.dart';
+
+import 'digibyte_wallet_addresses.dart';
+
+part 'digibyte_wallet.g.dart';
+
+class DigibyteWallet = DigibyteWalletBase with _$DigibyteWallet;
+
+abstract class DigibyteWalletBase extends ElectrumWallet with Store {
+  DigibyteWalletBase({
+    required String mnemonic,
+    required String password,
+    required WalletInfo walletInfo,
+    required Box<UnspentCoinsInfo> unspentCoinsInfo,
+    required Uint8List seedBytes,
+    required EncryptionFileUtils encryptionFileUtils,
+    String? passphrase,
+    BitcoinAddressType? addressPageType,
+    List<BitcoinAddressRecord>? initialAddresses,
+    ElectrumBalance? initialBalance,
+    Map<String, int>? initialRegularAddressIndex,
+    Map<String, int>? initialChangeAddressIndex,
+  }) : super(
+            mnemonic: mnemonic,
+            password: password,
+            walletInfo: walletInfo,
+            unspentCoinsInfo: unspentCoinsInfo,
+            network: DigibyteNetwork.mainnet,
+            initialAddresses: initialAddresses,
+            initialBalance: initialBalance,
+            seedBytes: seedBytes,
+            currency: CryptoCurrency.digibyte,
+            encryptionFileUtils: encryptionFileUtils,
+            passphrase: passphrase) {
+    walletAddresses = DigibyteWalletAddresses(
+      walletInfo,
+      initialAddresses: initialAddresses,
+      initialRegularAddressIndex: initialRegularAddressIndex,
+      initialChangeAddressIndex: initialChangeAddressIndex,
+      mainHd: hd,
+      sideHd: accountHD.childKey(Bip32KeyIndex(1)),
+      network: network,
+      initialAddressPageType: addressPageType,
+      isHardwareWallet: walletInfo.isHardwareWallet,
+    );
+    autorun((_) {
+      this.walletAddresses.isEnabledAutoGenerateSubaddress = this.isEnabledAutoGenerateSubaddress;
+    });
+  }
+
+  static Future<DigibyteWallet> create(
+      {required String mnemonic,
+      required String password,
+      required WalletInfo walletInfo,
+      required Box<UnspentCoinsInfo> unspentCoinsInfo,
+      required EncryptionFileUtils encryptionFileUtils,
+      String? passphrase,
+      String? addressPageType,
+      List<BitcoinAddressRecord>? initialAddresses,
+      ElectrumBalance? initialBalance,
+      Map<String, int>? initialRegularAddressIndex,
+      Map<String, int>? initialChangeAddressIndex}) async {
+    return DigibyteWallet(
+      mnemonic: mnemonic,
+      password: password,
+      walletInfo: walletInfo,
+      unspentCoinsInfo: unspentCoinsInfo,
+      initialAddresses: initialAddresses,
+      initialBalance: initialBalance,
+      seedBytes: MnemonicBip39.toSeed(mnemonic, passphrase: passphrase),
+      encryptionFileUtils: encryptionFileUtils,
+      initialRegularAddressIndex: initialRegularAddressIndex,
+      initialChangeAddressIndex: initialChangeAddressIndex,
+      addressPageType: P2pkhAddressType.p2pkh,
+      passphrase: passphrase,
+    );
+  }
+
+  static Future<DigibyteWallet> open({
+    required String name,
+    required WalletInfo walletInfo,
+    required Box<UnspentCoinsInfo> unspentCoinsInfo,
+    required String password,
+    required EncryptionFileUtils encryptionFileUtils,
+  }) async {
+    final hasKeysFile = await WalletKeysFile.hasKeysFile(name, walletInfo.type);
+
+    ElectrumWalletSnapshot? snp = null;
+
+    try {
+      snp = await ElectrumWalletSnapshot.load(
+        encryptionFileUtils,
+        name,
+        walletInfo.type,
+        password,
+        DigibyteNetwork.mainnet,
+      );
+    } catch (e) {
+      if (!hasKeysFile) rethrow;
+    }
+
+    final WalletKeysData keysData;
+    // Migrate wallet from the old scheme to then new .keys file scheme
+    if (!hasKeysFile) {
+      keysData =
+          WalletKeysData(mnemonic: snp!.mnemonic, xPub: snp.xpub, passphrase: snp.passphrase);
+    } else {
+      keysData = await WalletKeysFile.readKeysFile(
+        name,
+        walletInfo.type,
+        password,
+        encryptionFileUtils,
+      );
+    }
+
+    return DigibyteWallet(
+      mnemonic: keysData.mnemonic!,
+      password: password,
+      walletInfo: walletInfo,
+      unspentCoinsInfo: unspentCoinsInfo,
+      initialAddresses: snp?.addresses,
+      initialBalance: snp?.balance,
+      seedBytes: await MnemonicBip39.toSeed(keysData.mnemonic!, passphrase: keysData.passphrase),
+      encryptionFileUtils: encryptionFileUtils,
+      initialRegularAddressIndex: snp?.regularAddressIndex,
+      initialChangeAddressIndex: snp?.changeAddressIndex,
+      addressPageType: P2pkhAddressType.p2pkh,
+      passphrase: keysData.passphrase,
+    );
+  }
+
+  @override
+  Future<String> signMessage(String message, {String? address = null}) async {
+    int? index;
+    try {
+      index = address != null
+          ? walletAddresses.allAddresses.firstWhere((element) => element.address == address).index
+          : null;
+    } catch (_) {}
+    final HD = index == null ? hd : hd.childKey(Bip32KeyIndex(index));
+    final priv = ECPrivate.fromWif(
+      WifEncoder.encode(HD.privateKey.raw, netVer: network.wifNetVer),
+      netVersion: network.wifNetVer,
+    );
+    return priv.signMessage(StringUtils.encode(message));
+  }
+}

--- a/cw_digibyte/lib/src/digibyte_wallet_addresses.dart
+++ b/cw_digibyte/lib/src/digibyte_wallet_addresses.dart
@@ -1,0 +1,29 @@
+import 'package:bitcoin_base/bitcoin_base.dart';
+import 'package:blockchain_utils/blockchain_utils.dart';
+import 'package:cw_bitcoin/electrum_wallet_addresses.dart';
+import 'package:cw_bitcoin/utils.dart';
+import 'package:cw_core/wallet_info.dart';
+import 'package:mobx/mobx.dart';
+
+part 'digibyte_wallet_addresses.g.dart';
+
+class DigibyteWalletAddresses = DigibyteWalletAddressesBase with _$DigibyteWalletAddresses;
+
+abstract class DigibyteWalletAddressesBase extends ElectrumWalletAddresses with Store {
+  DigibyteWalletAddressesBase(WalletInfo walletInfo, {
+    required super.mainHd,
+    required super.sideHd,
+    required super.network,
+    required super.isHardwareWallet,
+    super.initialAddresses,
+    super.initialRegularAddressIndex,
+    super.initialChangeAddressIndex,
+    super.initialAddressPageType
+  }) : super(walletInfo);
+
+  @override
+  String getAddress({required int index,
+    required Bip32Slip10Secp256k1 hd,
+    BitcoinAddressType? addressType}) =>
+      generateP2PKHAddress(hd: hd, index: index, network: network);
+}

--- a/cw_digibyte/lib/src/digibyte_wallet_creation_credentials.dart
+++ b/cw_digibyte/lib/src/digibyte_wallet_creation_credentials.dart
@@ -1,0 +1,38 @@
+import 'package:cw_core/wallet_credentials.dart';
+import 'package:cw_core/wallet_info.dart';
+
+class DigibyteNewWalletCredentials extends WalletCredentials {
+  DigibyteNewWalletCredentials({
+    required String name,
+    WalletInfo? walletInfo,
+    String? password,
+    String? passphrase,
+    this.mnemonic,
+  }) : super(
+          name: name,
+          walletInfo: walletInfo,
+          password: password,
+          passphrase: passphrase,
+        );
+  final String? mnemonic;
+}
+
+class DigibyteRestoreWalletFromSeedCredentials extends WalletCredentials {
+  DigibyteRestoreWalletFromSeedCredentials({
+    required String name,
+    required String password,
+    required this.mnemonic,
+    WalletInfo? walletInfo,
+    String? passphrase,
+  }) : super(name: name, password: password, walletInfo: walletInfo, passphrase: passphrase);
+
+  final String mnemonic;
+}
+
+class DigibyteRestoreWalletFromWIFCredentials extends WalletCredentials {
+  DigibyteRestoreWalletFromWIFCredentials(
+      {required String name, required String password, required this.wif, WalletInfo? walletInfo})
+      : super(name: name, password: password, walletInfo: walletInfo);
+
+  final String wif;
+}

--- a/cw_digibyte/lib/src/digibyte_wallet_service.dart
+++ b/cw_digibyte/lib/src/digibyte_wallet_service.dart
@@ -1,0 +1,151 @@
+import 'dart:io';
+
+import 'package:bip39/bip39.dart';
+import 'package:collection/collection.dart';
+import 'package:cw_bitcoin/bitcoin_mnemonics_bip39.dart';
+import 'package:cw_core/encryption_file_utils.dart';
+import 'package:cw_core/pathForWallet.dart';
+import 'package:cw_core/unspent_coins_info.dart';
+import 'package:cw_core/wallet_base.dart';
+import 'package:cw_core/wallet_info.dart';
+import 'package:cw_core/wallet_service.dart';
+import 'package:cw_core/wallet_type.dart';
+import 'package:cw_digibyte/cw_digibyte.dart';
+import 'package:hive/hive.dart';
+
+class DigibyteWalletService extends WalletService<
+    DigibyteNewWalletCredentials,
+    DigibyteRestoreWalletFromSeedCredentials,
+    DigibyteRestoreWalletFromWIFCredentials,
+    DigibyteNewWalletCredentials> {
+  DigibyteWalletService(this.walletInfoSource, this.unspentCoinsInfoSource, this.isDirect);
+
+  final Box<WalletInfo> walletInfoSource;
+  final Box<UnspentCoinsInfo> unspentCoinsInfoSource;
+  final bool isDirect;
+
+  @override
+  WalletType getType() => WalletType.digibyte;
+
+  @override
+  Future<bool> isWalletExit(String name) async =>
+      File(await pathForWallet(name: name, type: getType())).existsSync();
+
+  @override
+  Future<DigibyteWallet> create(credentials, {bool? isTestnet}) async {
+    final strength = credentials.seedPhraseLength == 24 ? 256 : 128;
+
+    final wallet = await DigibyteWalletBase.create(
+      mnemonic: credentials.mnemonic ?? MnemonicBip39.generate(strength: strength),
+      password: credentials.password!,
+      walletInfo: credentials.walletInfo!,
+      unspentCoinsInfo: unspentCoinsInfoSource,
+      encryptionFileUtils: encryptionFileUtilsFor(isDirect),
+      passphrase: credentials.passphrase,
+    );
+    await wallet.save();
+    await wallet.init();
+
+    return wallet;
+  }
+
+  @override
+  Future<DigibyteWallet> openWallet(String name, String password) async {
+    final walletInfo = walletInfoSource.values
+        .firstWhereOrNull((info) => info.id == WalletBase.idFor(name, getType()))!;
+
+    try {
+      final wallet = await DigibyteWalletBase.open(
+        password: password,
+        name: name,
+        walletInfo: walletInfo,
+        unspentCoinsInfo: unspentCoinsInfoSource,
+        encryptionFileUtils: encryptionFileUtilsFor(isDirect),
+      );
+      await wallet.init();
+      saveBackup(name);
+      return wallet;
+    } catch (_) {
+      await restoreWalletFilesFromBackup(name);
+      final wallet = await DigibyteWalletBase.open(
+        password: password,
+        name: name,
+        walletInfo: walletInfo,
+        unspentCoinsInfo: unspentCoinsInfoSource,
+        encryptionFileUtils: encryptionFileUtilsFor(isDirect),
+      );
+      await wallet.init();
+      return wallet;
+    }
+  }
+
+  @override
+  Future<void> remove(String wallet) async {
+    File(await pathForWalletDir(name: wallet, type: getType())).delete(recursive: true);
+    final walletInfo = walletInfoSource.values
+        .firstWhereOrNull((info) => info.id == WalletBase.idFor(wallet, getType()))!;
+    await walletInfoSource.delete(walletInfo.key);
+
+    final unspentCoinsToDelete = unspentCoinsInfoSource.values
+        .where((unspentCoin) => unspentCoin.walletId == walletInfo.id)
+        .toList();
+
+    final keysToDelete = unspentCoinsToDelete.map((unspentCoin) => unspentCoin.key).toList();
+
+    if (keysToDelete.isNotEmpty) {
+      await unspentCoinsInfoSource.deleteAll(keysToDelete);
+    }
+  }
+
+  @override
+  Future<void> rename(String currentName, String password, String newName) async {
+    final currentWalletInfo = walletInfoSource.values
+        .firstWhereOrNull((info) => info.id == WalletBase.idFor(currentName, getType()))!;
+    final currentWallet = await DigibyteWalletBase.open(
+        password: password,
+        name: currentName,
+        walletInfo: currentWalletInfo,
+        unspentCoinsInfo: unspentCoinsInfoSource,
+        encryptionFileUtils: encryptionFileUtilsFor(isDirect));
+
+    await currentWallet.renameWalletFiles(newName);
+    await saveBackup(newName);
+
+    final newWalletInfo = currentWalletInfo;
+    newWalletInfo.id = WalletBase.idFor(newName, getType());
+    newWalletInfo.name = newName;
+
+    await walletInfoSource.put(currentWalletInfo.key, newWalletInfo);
+  }
+
+  @override
+  Future<DigibyteWallet> restoreFromHardwareWallet(DigibyteNewWalletCredentials credentials) {
+    throw UnimplementedError(
+        'Restoring a DigiByte wallet from a hardware wallet is not yet supported!');
+  }
+
+  @override
+  Future<DigibyteWallet> restoreFromKeys(credentials, {bool? isTestnet}) {
+    // TODO: implement restoreFromKeys
+    throw UnimplementedError('restoreFromKeys() is not implemented');
+  }
+
+  @override
+  Future<DigibyteWallet> restoreFromSeed(DigibyteRestoreWalletFromSeedCredentials credentials,
+      {bool? isTestnet}) async {
+    if (!validateMnemonic(credentials.mnemonic)) {
+      throw Exception('Invalid mnemonic: ${credentials.mnemonic}');
+    }
+
+    final wallet = await DigibyteWalletBase.create(
+        password: credentials.password!,
+        mnemonic: credentials.mnemonic,
+        walletInfo: credentials.walletInfo!,
+        unspentCoinsInfo: unspentCoinsInfoSource,
+        encryptionFileUtils: encryptionFileUtilsFor(isDirect),
+        passphrase: credentials.passphrase);
+    await wallet.save();
+    await wallet.init();
+    return wallet;
+  }
+}

--- a/cw_digibyte/pubspec.yaml
+++ b/cw_digibyte/pubspec.yaml
@@ -1,0 +1,80 @@
+name: cw_digibyte
+description: DigiByte Electrum wallet integration for Cake Wallet.
+version: 0.0.1
+publish_to: none
+author: Cake Wallet
+homepage: https://cakewallet.com
+
+environment:
+  sdk: '>=2.19.0 <3.0.0'
+  flutter: ">=1.20.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+  bip39: ^1.0.6
+  path_provider: ^2.0.11
+  mobx: ^2.0.7+4
+  flutter_mobx: ^2.0.6+1
+  cw_core:
+    path: ../cw_core
+  cw_bitcoin:
+    path: ../cw_bitcoin
+
+  blockchain_utils:
+    git:
+      url: https://github.com/cake-tech/blockchain_utils
+      ref: cake-update-v2
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  build_runner: ^2.4.15
+  mobx_codegen: ^2.0.7
+  hive_generator: ^2.0.1
+
+dependency_overrides:
+  watcher: ^1.1.0
+  bitcoin_base:
+    git:
+      url: https://github.com/cake-tech/bitcoin_base
+      ref: cake-update-v11
+
+
+# For information on the generic Dart part of this file, see the
+# following page: https://dart.dev/tools/pub/pubspec
+
+# The following section is specific to Flutter packages.
+flutter:
+  uses-material-design: true
+
+  # To add assets to your package, add an assets section, like this:
+  # assets:
+  #   - images/a_dot_burr.jpeg
+  #   - images/a_dot_ham.jpeg
+  #
+  # For details regarding assets in packages, see
+  # https://flutter.dev/to/asset-from-package
+  #
+  # An image asset can refer to one or more resolution-specific "variants", see
+  # https://flutter.dev/to/resolution-aware-images
+
+  # To add custom fonts to your package, add a fonts section here,
+  # in this "flutter" section. Each entry in this list should have a
+  # "family" key with the font family name, and a "fonts" key with a
+  # list giving the asset and other descriptors for the font. For
+  # example:
+  # fonts:
+  #   - family: Schyler
+  #     fonts:
+  #       - asset: fonts/Schyler-Regular.ttf
+  #       - asset: fonts/Schyler-Italic.ttf
+  #         style: italic
+  #   - family: Trajan Pro
+  #     fonts:
+  #       - asset: fonts/TrajanPro.ttf
+  #       - asset: fonts/TrajanPro_Bold.ttf
+  #         weight: 700
+  #
+  # For details regarding fonts in packages, see
+  # https://flutter.dev/to/font-from-package

--- a/cw_digibyte/test/cw_digibyte_test.dart
+++ b/cw_digibyte/test/cw_digibyte_test.dart
@@ -1,0 +1,8 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:cw_digibyte/cw_digibyte.dart';
+
+void main() {
+  test('adds one to input values', () {
+  });
+}

--- a/lib/di.dart
+++ b/lib/di.dart
@@ -10,6 +10,7 @@ import 'package:cake_wallet/bitcoin_cash/bitcoin_cash.dart';
 import 'package:cake_wallet/buy/dfx/dfx_buy_provider.dart';
 import 'package:cake_wallet/buy/moonpay/moonpay_provider.dart';
 import 'package:cake_wallet/buy/onramper/onramper_buy_provider.dart';
+import 'package:cake_wallet/digibyte/digibyte.dart';
 import 'package:cake_wallet/order/order.dart';
 import 'package:cake_wallet/core/backup_service_v3.dart';
 import 'package:cake_wallet/core/new_wallet_arguments.dart';
@@ -1193,7 +1194,11 @@ Future<void> setup({
         return dogecoin!.createDogeCoinWalletService(_walletInfoSource,
             _unspentCoinsInfoSource, SettingsStoreBase.walletPasswordDirectInput);
       case WalletType.digibyte:
-        throw UnimplementedError('DigiByte wallet service is not yet wired');
+        return digibyte!.createDigibyteWalletService(
+          _walletInfoSource,
+          _unspentCoinsInfoSource,
+          SettingsStoreBase.walletPasswordDirectInput,
+        );
       case WalletType.nano:
       case WalletType.banano:
         return nano!.createNanoWalletService(_walletInfoSource, SettingsStoreBase.walletPasswordDirectInput);

--- a/lib/digibyte/cw_digibyte.dart
+++ b/lib/digibyte/cw_digibyte.dart
@@ -1,0 +1,66 @@
+part of 'digibyte.dart';
+
+class CWDigibyte extends Digibyte {
+  @override
+  WalletService createDigibyteWalletService(
+      Box<WalletInfo> walletInfoSource, Box<UnspentCoinsInfo> unspentCoinSource, bool isDirect) {
+    return DigibyteWalletService(walletInfoSource, unspentCoinSource, isDirect);
+  }
+
+  @override
+  WalletCredentials createDigibyteNewWalletCredentials({
+    required String name,
+    WalletInfo? walletInfo,
+    String? password,
+    String? passphrase,
+    String? mnemonic,
+  }) =>
+      DigibyteNewWalletCredentials(
+        name: name,
+        walletInfo: walletInfo,
+        password: password,
+        passphrase: passphrase,
+        mnemonic: mnemonic,
+      );
+
+  @override
+  WalletCredentials createDigibyteRestoreWalletFromSeedCredentials({
+    required String name,
+    required String mnemonic,
+    required String password,
+    String? passphrase,
+  }) =>
+      DigibyteRestoreWalletFromSeedCredentials(
+        name: name,
+        mnemonic: mnemonic,
+        password: password,
+        passphrase: passphrase,
+      );
+
+  @override
+  WalletCredentials createDigibyteRestoreWalletFromWIFCredentials({
+    required String name,
+    required String password,
+    required String wif,
+    WalletInfo? walletInfo,
+  }) =>
+      DigibyteRestoreWalletFromWIFCredentials(
+        name: name,
+        password: password,
+        wif: wif,
+        walletInfo: walletInfo,
+      );
+
+  @override
+  TransactionPriority deserializeDigibyteTransactionPriority(int raw) =>
+      DigibyteTransactionPriority.deserialize(raw: raw);
+
+  @override
+  TransactionPriority getDefaultTransactionPriority() => DigibyteTransactionPriority.medium;
+
+  @override
+  List<TransactionPriority> getTransactionPriorities() => DigibyteTransactionPriority.all;
+
+  @override
+  TransactionPriority getDigibyteTransactionPrioritySlow() => DigibyteTransactionPriority.slow;
+}

--- a/lib/entities/preferences_key.dart
+++ b/lib/entities/preferences_key.dart
@@ -54,6 +54,7 @@ class PreferencesKey {
   static const zanoTransactionPriority = 'current_fee_priority_zano';
   static const wowneroTransactionPriority = 'current_fee_priority_wownero';
   static const decredTransactionPriority = 'current_fee_priority_decred';
+  static const digibyteTransactionPriority = 'current_fee_priority_digibyte';
   static const customBitcoinFeeRate = 'custom_electrum_fee_rate';
   static const silentPaymentsCardDisplay = 'silentPaymentsCardDisplay';
   static const mwebCardDisplay = 'mwebCardDisplay';

--- a/lib/entities/priority_for_wallet_type.dart
+++ b/lib/entities/priority_for_wallet_type.dart
@@ -7,6 +7,7 @@ import 'package:cake_wallet/polygon/polygon.dart';
 import 'package:cake_wallet/wownero/wownero.dart';
 import 'package:cake_wallet/zano/zano.dart';
 import 'package:cake_wallet/decred/decred.dart';
+import 'package:cake_wallet/digibyte/digibyte.dart';
 import 'package:cw_core/transaction_priority.dart';
 import 'package:cw_core/wallet_type.dart';
 
@@ -27,7 +28,7 @@ List<TransactionPriority> priorityForWalletType(WalletType type) {
     case WalletType.dogecoin:
       return dogecoin!.getTransactionPriorities();
     case WalletType.digibyte:
-      return const [];
+      return digibyte!.getTransactionPriorities();
     case WalletType.polygon:
       return polygon!.getTransactionPriorities();
     // no such thing for nano/banano/solana/tron:

--- a/lib/store/settings_store.dart
+++ b/lib/store/settings_store.dart
@@ -27,6 +27,7 @@ import 'package:cake_wallet/entities/sort_balance_types.dart';
 import 'package:cake_wallet/entities/sync_status_display_mode.dart';
 import 'package:cake_wallet/entities/wallet_list_order_types.dart';
 import 'package:cake_wallet/ethereum/ethereum.dart';
+import 'package:cake_wallet/digibyte/digibyte.dart';
 import 'package:cake_wallet/wownero/wownero.dart';
 import 'package:cake_wallet/zano/zano.dart';
 import 'package:cw_core/transaction_priority.dart';
@@ -140,6 +141,7 @@ abstract class SettingsStoreBase with Store {
       TransactionPriority? initialEthereumTransactionPriority,
       TransactionPriority? initialPolygonTransactionPriority,
       TransactionPriority? initialBitcoinCashTransactionPriority,
+      TransactionPriority? initialDigibyteTransactionPriority,
       TransactionPriority? initialZanoTransactionPriority,
       TransactionPriority? initialDecredTransactionPriority,
       Country? initialCakePayCountry})
@@ -228,6 +230,10 @@ abstract class SettingsStoreBase with Store {
       priority[WalletType.bitcoinCash] = initialBitcoinCashTransactionPriority;
     }
 
+    if (initialDigibyteTransactionPriority != null) {
+      priority[WalletType.digibyte] = initialDigibyteTransactionPriority;
+    }
+
     if (initialZanoTransactionPriority != null) {
       priority[WalletType.zano] = initialZanoTransactionPriority;
     }
@@ -287,6 +293,9 @@ abstract class SettingsStoreBase with Store {
           break;
         case WalletType.bitcoinCash:
           key = PreferencesKey.bitcoinCashTransactionPriority;
+          break;
+        case WalletType.digibyte:
+          key = PreferencesKey.digibyteTransactionPriority;
           break;
         case WalletType.polygon:
           key = PreferencesKey.polygonTransactionPriority;
@@ -950,6 +959,7 @@ abstract class SettingsStoreBase with Store {
     TransactionPriority? ethereumTransactionPriority;
     TransactionPriority? polygonTransactionPriority;
     TransactionPriority? bitcoinCashTransactionPriority;
+    TransactionPriority? digibyteTransactionPriority;
     TransactionPriority? wowneroTransactionPriority;
     TransactionPriority? zanoTransactionPriority;
     TransactionPriority? decredTransactionPriority;
@@ -974,6 +984,10 @@ abstract class SettingsStoreBase with Store {
       bitcoinCashTransactionPriority = bitcoinCash?.deserializeBitcoinCashTransactionPriority(
           sharedPreferences.getInt(PreferencesKey.bitcoinCashTransactionPriority)!);
     }
+    if (sharedPreferences.getInt(PreferencesKey.digibyteTransactionPriority) != null) {
+      digibyteTransactionPriority = digibyte?.deserializeDigibyteTransactionPriority(
+          sharedPreferences.getInt(PreferencesKey.digibyteTransactionPriority)!);
+    }
     if (sharedPreferences.getInt(PreferencesKey.wowneroTransactionPriority) != null) {
       wowneroTransactionPriority = wownero?.deserializeWowneroTransactionPriority(
           raw: sharedPreferences.getInt(PreferencesKey.wowneroTransactionPriority)!);
@@ -993,6 +1007,7 @@ abstract class SettingsStoreBase with Store {
     litecoinTransactionPriority ??= bitcoin?.getLitecoinTransactionPriorityMedium();
     ethereumTransactionPriority ??= ethereum?.getDefaultTransactionPriority();
     bitcoinCashTransactionPriority ??= bitcoinCash?.getDefaultTransactionPriority();
+    digibyteTransactionPriority ??= digibyte?.getDefaultTransactionPriority();
     wowneroTransactionPriority ??= wownero?.getDefaultTransactionPriority();
     decredTransactionPriority ??= decred?.getDecredTransactionPriorityMedium();
     polygonTransactionPriority ??= polygon?.getDefaultTransactionPriority();
@@ -1095,7 +1110,6 @@ abstract class SettingsStoreBase with Store {
     final zanoNodeId = sharedPreferences.getInt(PreferencesKey.currentZanoNodeIdKey);
     final decredNodeId = sharedPreferences.getInt(PreferencesKey.currentDecredNodeIdKey);
     final dogecoinNodeId = sharedPreferences.getInt(PreferencesKey.currentDogecoinNodeIdKey);
-    final digibyteNodeId = sharedPreferences.getInt(PreferencesKey.currentDigibyteNodeIdKey);
     final digibyteNodeId = sharedPreferences.getInt(PreferencesKey.currentDigibyteNodeIdKey);
 
     /// get the selected node, if null, then use the default
@@ -1396,6 +1410,7 @@ abstract class SettingsStoreBase with Store {
       initialHavenTransactionPriority: havenTransactionPriority,
       initialLitecoinTransactionPriority: litecoinTransactionPriority,
       initialBitcoinCashTransactionPriority: bitcoinCashTransactionPriority,
+      initialDigibyteTransactionPriority: digibyteTransactionPriority,
       initialDecredTransactionPriority: decredTransactionPriority,
       initialShouldRequireTOTP2FAForAccessingWallet: shouldRequireTOTP2FAForAccessingWallet,
       initialShouldRequireTOTP2FAForSendsToContact: shouldRequireTOTP2FAForSendsToContact,
@@ -1467,6 +1482,11 @@ abstract class SettingsStoreBase with Store {
         sharedPreferences.getInt(PreferencesKey.bitcoinCashTransactionPriority) != null) {
       priority[WalletType.bitcoinCash] = bitcoinCash!.deserializeBitcoinCashTransactionPriority(
           sharedPreferences.getInt(PreferencesKey.bitcoinCashTransactionPriority)!);
+    }
+    if (digibyte != null &&
+        sharedPreferences.getInt(PreferencesKey.digibyteTransactionPriority) != null) {
+      priority[WalletType.digibyte] = digibyte!.deserializeDigibyteTransactionPriority(
+          sharedPreferences.getInt(PreferencesKey.digibyteTransactionPriority)!);
     }
     if (zano != null && sharedPreferences.getInt(PreferencesKey.zanoTransactionPriority) != null) {
       priority[WalletType.zano] = zano!.deserializeMoneroTransactionPriority(

--- a/lib/view_model/send/fees_view_model.dart
+++ b/lib/view_model/send/fees_view_model.dart
@@ -1,5 +1,6 @@
 import 'package:cake_wallet/bitcoin_cash/bitcoin_cash.dart';
 import 'package:cake_wallet/decred/decred.dart';
+import 'package:cake_wallet/digibyte/digibyte.dart';
 import 'package:cake_wallet/dogecoin/dogecoin.dart';
 import 'package:cake_wallet/entities/priority_for_wallet_type.dart';
 import 'package:cake_wallet/core/wallet_change_listener_view_model.dart';
@@ -95,7 +96,7 @@ abstract class FeesViewModelBase extends WalletChangeListenerViewModel with Stor
       case WalletType.dogecoin:
         return transactionPriority == dogecoin!.getDogeCoinTransactionPrioritySlow();
       case WalletType.digibyte:
-        return false;
+        return transactionPriority == digibyte!.getDigibyteTransactionPrioritySlow();
       case WalletType.none:
       case WalletType.nano:
       case WalletType.banano:
@@ -197,6 +198,9 @@ abstract class FeesViewModelBase extends WalletChangeListenerViewModel with Stor
         break;
       case WalletType.dogecoin:
         _settingsStore.priority[wallet.type] = dogecoin!.getDefaultTransactionPriority();
+        break;
+      case WalletType.digibyte:
+        _settingsStore.priority[wallet.type] = digibyte!.getDefaultTransactionPriority();
         break;
       case WalletType.polygon:
         _settingsStore.priority[wallet.type] = polygon!.getDefaultTransactionPriority();

--- a/lib/view_model/wallet_new_vm.dart
+++ b/lib/view_model/wallet_new_vm.dart
@@ -6,6 +6,7 @@ import 'package:cake_wallet/bitcoin_cash/bitcoin_cash.dart';
 import 'package:cake_wallet/solana/solana.dart';
 import 'package:cake_wallet/tron/tron.dart';
 import 'package:cake_wallet/wownero/wownero.dart';
+import 'package:cake_wallet/digibyte/digibyte.dart';
 import 'package:hive/hive.dart';
 import 'package:mobx/mobx.dart';
 import 'package:cake_wallet/bitcoin/bitcoin.dart';
@@ -105,7 +106,12 @@ abstract class WalletNewVMBase extends WalletCreationVM with Store {
           mnemonic: newWalletArguments!.mnemonic,
         );
       case WalletType.digibyte:
-        throw UnimplementedError('DigiByte wallet creation is pending integration');
+        return digibyte!.createDigibyteNewWalletCredentials(
+          name: name,
+          password: walletPassword,
+          passphrase: passphrase,
+          mnemonic: newWalletArguments!.mnemonic,
+        );
       case WalletType.nano:
       case WalletType.banano:
         return nano!.createNanoNewWalletCredentials(

--- a/lib/view_model/wallet_restore_view_model.dart
+++ b/lib/view_model/wallet_restore_view_model.dart
@@ -12,6 +12,7 @@ import 'package:cake_wallet/solana/solana.dart';
 import 'package:cake_wallet/store/app_store.dart';
 import 'package:cake_wallet/tron/tron.dart';
 import 'package:cake_wallet/decred/decred.dart';
+import 'package:cake_wallet/digibyte/digibyte.dart';
 import 'package:cake_wallet/utils/feature_flag.dart';
 import 'package:cake_wallet/view_model/restore/restore_mode.dart';
 import 'package:cake_wallet/view_model/restore/restore_wallet.dart';
@@ -159,7 +160,12 @@ abstract class WalletRestoreViewModelBase extends WalletCreationVM with Store {
             passphrase: passphrase,
           );
         case WalletType.digibyte:
-          throw UnimplementedError('DigiByte restore flow is pending implementation');
+          return digibyte!.createDigibyteRestoreWalletFromSeedCredentials(
+            name: name,
+            mnemonic: seed,
+            password: password,
+            passphrase: passphrase,
+          );
         case WalletType.nano:
         case WalletType.banano:
           return nano!.createNanoRestoreWalletFromSeedCredentials(

--- a/model_generator.sh
+++ b/model_generator.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -x -e
 
-for cwcoin in cw_{core,evm,monero,bitcoin,nano,bitcoin_cash,solana,tron,wownero,zano,decred,dogecoin}
+for cwcoin in cw_{core,evm,monero,bitcoin,nano,bitcoin_cash,solana,tron,wownero,zano,decred,dogecoin,digibyte}
 do
     if [[ "x$1" == "xasync" ]];
     then

--- a/scripts/android/pubspec_gen.sh
+++ b/scripts/android/pubspec_gen.sh
@@ -10,7 +10,7 @@ case $APP_ANDROID_TYPE in
                 CONFIG_ARGS="--monero"
                 ;;
         $CAKEWALLET)
-                CONFIG_ARGS="--monero --bitcoin --ethereum --polygon --nano --bitcoinCash --solana --tron --wownero --zano --decred --dogecoin"
+                CONFIG_ARGS="--monero --bitcoin --ethereum --polygon --nano --bitcoinCash --solana --tron --wownero --zano --decred --dogecoin --digibyte"
                 ;;
 esac
 

--- a/scripts/ios/app_config.sh
+++ b/scripts/ios/app_config.sh
@@ -31,7 +31,7 @@ case $APP_IOS_TYPE in
 		;;
 
         $CAKEWALLET)
-		CONFIG_ARGS="--monero --bitcoin --ethereum --polygon --nano --bitcoinCash --solana --tron --wownero --zano --decred --dogecoin"
+                CONFIG_ARGS="--monero --bitcoin --ethereum --polygon --nano --bitcoinCash --solana --tron --wownero --zano --decred --dogecoin --digibyte"
 		;;
 esac
 

--- a/scripts/linux/app_config.sh
+++ b/scripts/linux/app_config.sh
@@ -13,7 +13,7 @@ CONFIG_ARGS=""
 
 case $APP_LINUX_TYPE in
         $CAKEWALLET)
-		CONFIG_ARGS="--monero --bitcoin --ethereum --polygon --nano --bitcoinCash --solana --tron --wownero --dogecoin --excludeFlutterSecureStorage";;
+                CONFIG_ARGS="--monero --bitcoin --ethereum --polygon --nano --bitcoinCash --solana --tron --wownero --dogecoin --digibyte --excludeFlutterSecureStorage";;
 esac
 
 cp -rf pubspec_description.yaml pubspec.yaml

--- a/scripts/macos/app_config.sh
+++ b/scripts/macos/app_config.sh
@@ -36,7 +36,7 @@ case $APP_MACOS_TYPE in
         $MONERO_COM)
 		CONFIG_ARGS="--monero";;
         $CAKEWALLET)
-		CONFIG_ARGS="--monero --bitcoin --ethereum --polygon --nano --bitcoinCash --solana --tron --wownero --dogecoin";;
+                CONFIG_ARGS="--monero --bitcoin --ethereum --polygon --nano --bitcoinCash --solana --tron --wownero --dogecoin --digibyte";;
 esac
 
 cp -rf pubspec_description.yaml pubspec.yaml


### PR DESCRIPTION
## Summary
- add a dedicated `cw_digibyte` package with wallet, service, address, and priority implementations for DigiByte
- wire DigiByte support into dependency injection, wallet creation and restore flows, and fee priority handling
- extend settings and preference keys so DigiByte fee priorities are persisted alongside other Electrum wallets

## Testing
- not run (Dart SDK is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_b_68cbe23c0bb4832bab21174e4e861199