### PR TITLE
Add DigiByte support across wallet view models

### DIFF
--- a/lib/view_model/advanced_privacy_settings_view_model.dart
+++ b/lib/view_model/advanced_privacy_settings_view_model.dart
@@ -45,6 +45,7 @@ abstract class AdvancedPrivacySettingsViewModelBase with Store {
 
       case WalletType.bitcoin:
       case WalletType.litecoin:
+      case WalletType.digibyte:
         return _settingsStore.bitcoinSeedType == BitcoinSeedType.bip39;
 
       case WalletType.nano:
@@ -69,6 +70,7 @@ abstract class AdvancedPrivacySettingsViewModelBase with Store {
   bool get isBitcoinSeedTypeOptionsEnabled => [
         WalletType.bitcoin,
         WalletType.litecoin,
+        WalletType.digibyte,
       ].contains(type);
 
   bool get isNanoSeedTypeOptionsEnabled => [WalletType.nano].contains(type);
@@ -85,6 +87,7 @@ abstract class AdvancedPrivacySettingsViewModelBase with Store {
         WalletType.wownero,
         WalletType.zano,
         WalletType.dogecoin,
+        WalletType.digibyte,
       ].contains(type);
 
   @computed

--- a/lib/view_model/dashboard/dashboard_view_model.dart
+++ b/lib/view_model/dashboard/dashboard_view_model.dart
@@ -880,6 +880,7 @@ abstract class DashboardViewModelBase with Store {
       case WalletType.wownero:
       case WalletType.decred:
       case WalletType.dogecoin:
+      case WalletType.digibyte:
         return true;
       case WalletType.zano:
       case WalletType.haven:

--- a/lib/view_model/dashboard/home_settings_view_model.dart
+++ b/lib/view_model/dashboard/home_settings_view_model.dart
@@ -237,6 +237,7 @@ abstract class HomeSettingsViewModelBase with Store {
       case WalletType.bitcoinCash:
       case WalletType.decred:
       case WalletType.dogecoin:
+      case WalletType.digibyte:
         return false;
     }
 

--- a/lib/view_model/dashboard/transaction_list_item.dart
+++ b/lib/view_model/dashboard/transaction_list_item.dart
@@ -168,6 +168,7 @@ class TransactionListItem extends ActionListItem with Keyable {
       case WalletType.litecoin:
       case WalletType.bitcoinCash:
       case WalletType.dogecoin:
+      case WalletType.digibyte:
         amount = calculateFiatAmountRaw(
             cryptoAmount: bitcoin!.formatterBitcoinAmountToDouble(amount: transaction.amount),
             price: price);

--- a/lib/view_model/exchange/exchange_view_model.dart
+++ b/lib/view_model/exchange/exchange_view_model.dart
@@ -827,6 +827,10 @@ abstract class ExchangeViewModelBase extends WalletChangeListenerViewModel with 
         depositCurrency = CryptoCurrency.doge;
         receiveCurrency = CryptoCurrency.xmr;
         break;
+      case WalletType.digibyte:
+        depositCurrency = CryptoCurrency.digibyte;
+        receiveCurrency = CryptoCurrency.xmr;
+        break;
       case WalletType.haven:
         depositCurrency = CryptoCurrency.xhv;
         receiveCurrency = CryptoCurrency.btc;

--- a/lib/view_model/node_list/node_create_or_edit_view_model.dart
+++ b/lib/view_model/node_list/node_create_or_edit_view_model.dart
@@ -93,6 +93,7 @@ abstract class NodeCreateOrEditViewModelBase with Store {
       case WalletType.bitcoinCash:
       case WalletType.bitcoin:
       case WalletType.dogecoin:
+      case WalletType.digibyte:
       case WalletType.zano:
       case WalletType.decred:
         return false;

--- a/lib/view_model/transaction_details_view_model.dart
+++ b/lib/view_model/transaction_details_view_model.dart
@@ -89,6 +89,7 @@ abstract class TransactionDetailsViewModelBase with Store {
         _addDecredListItems(tx, dateFormat);
         break;
       case WalletType.dogecoin:
+      case WalletType.digibyte:
         _addDogecoinListItems(tx, dateFormat);
         break;
       case WalletType.none:
@@ -198,6 +199,8 @@ abstract class TransactionDetailsViewModelBase with Store {
         return 'https://${wallet.isTestnet ? "testnet" : "dcrdata"}.decred.org/tx/${txId.split(':')[0]}';
       case WalletType.dogecoin:
         return 'https://blockchair.com/dogecoin/transaction/${txId}';
+      case WalletType.digibyte:
+        return 'https://blockchair.com/digibyte/transaction/${txId}';
       case WalletType.none:
         return '';
     }
@@ -212,6 +215,7 @@ abstract class TransactionDetailsViewModelBase with Store {
       case WalletType.litecoin:
       case WalletType.bitcoinCash:
       case WalletType.dogecoin:
+      case WalletType.digibyte:
         return S.current.view_transaction_on + 'Blockchair.com';
       case WalletType.haven:
         return S.current.view_transaction_on + 'explorer.havenprotocol.org';

--- a/lib/view_model/wallet_address_list/wallet_address_list_view_model.dart
+++ b/lib/view_model/wallet_address_list/wallet_address_list_view_model.dart
@@ -259,6 +259,22 @@ class DogeURI extends PaymentURI {
   }
 }
 
+class DigibyteURI extends PaymentURI {
+  DigibyteURI({required String amount, required String address})
+      : super(amount: amount, address: address);
+
+  @override
+  String toString() {
+    var base = 'digibyte:' + address;
+
+    if (amount.isNotEmpty) {
+      base += '?amount=${amount.replaceAll(',', '.')}';
+    }
+
+    return base;
+  }
+}
+
 abstract class WalletAddressListViewModelBase extends WalletChangeListenerViewModel with Store {
   WalletAddressListViewModelBase({
     required AppStore appStore,
@@ -363,6 +379,8 @@ abstract class WalletAddressListViewModelBase extends WalletChangeListenerViewMo
         return DecredURI(amount: amount, address: address.address);
       case WalletType.dogecoin:
         return DogeURI(amount: amount, address: address.address);
+      case WalletType.digibyte:
+        return DigibyteURI(amount: amount, address: address.address);
       case WalletType.none:
         throw Exception('Unexpected type: ${type.toString()}');
     }
@@ -607,6 +625,7 @@ abstract class WalletAddressListViewModelBase extends WalletChangeListenerViewMo
         WalletType.litecoin,
         WalletType.decred,
         WalletType.dogecoin,
+        WalletType.digibyte,
       ].contains(wallet.type);
 
   @computed
@@ -614,7 +633,8 @@ abstract class WalletAddressListViewModelBase extends WalletChangeListenerViewMo
         WalletType.bitcoin,
         WalletType.litecoin,
         WalletType.bitcoinCash,
-        WalletType.dogecoin
+        WalletType.dogecoin,
+        WalletType.digibyte
       ].contains(wallet.type);
 
   @computed

--- a/lib/view_model/wallet_keys_view_model.dart
+++ b/lib/view_model/wallet_keys_view_model.dart
@@ -165,6 +165,7 @@ abstract class WalletKeysViewModelBase with Store {
       case WalletType.litecoin:
       case WalletType.bitcoinCash:
       case WalletType.dogecoin:
+      case WalletType.digibyte:
         if (_wallet.type == WalletType.bitcoin) {
           keys = bitcoin!.getSilentPaymentKeys(_appStore.wallet!);
         }
@@ -264,6 +265,8 @@ abstract class WalletKeysViewModelBase with Store {
         return 'decred-wallet';
       case WalletType.dogecoin:
         return 'dogecoin-wallet';
+      case WalletType.digibyte:
+        return 'digibyte-wallet';
       default:
         throw Exception('Unexpected wallet type: ${_wallet.type.toString()}');
     }


### PR DESCRIPTION
## Summary
- treat DigiByte wallets as bitcoin-like across address, key, and dashboard view models
- enable DigiByte defaults for exchange pairing, node editing, and transaction explorers

## Testing
- `dart format lib/view_model/wallet_address_list/wallet_address_list_view_model.dart lib/view_model/dashboard/home_settings_view_model.dart lib/view_model/advanced_privacy_settings_view_model.dart lib/view_model/dashboard/dashboard_view_model.dart lib/view_model/exchange/exchange_view_model.dart lib/view_model/node_list/node_create_or_edit_view_model.dart lib/view_model/transaction_details_view_model.dart lib/view_model/wallet_keys_view_model.dart lib/view_model/dashboard/transaction_list_item.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68d12484a2e8832bb24fb95f816240bb